### PR TITLE
v5.0.1 hot fix release

### DIFF
--- a/conda-recipe/unix/rsmtool/meta.yaml
+++ b/conda-recipe/unix/rsmtool/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rsmtool
-  version: 5.0.0
+  version: 5.0.1
 
 source:
   path: ../../../../rsmtool

--- a/conda-recipe/windows/rsmtool/meta.yaml
+++ b/conda-recipe/windows/rsmtool/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rsmtool
-  version: 5.0.0
+  version: 5.0.1
 
 source:
   path: ../../../../rsmtool

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v5.0.1 (June 7, 2016)
+
+### Bugfixes
+
+* RSMCompare now does not switch the old and new experiments in the report.
+
 ## v5.0.0 (June 3, 2016)
 
 ### New features

--- a/rsmtool/version.py
+++ b/rsmtool/version.py
@@ -3,5 +3,5 @@ This module exists solely for version information so I only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 """
 
-__version__ = '5.0.0'
+__version__ = '5.0.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
- This fixes the `rsmcompare` issue of accidentally swapping the old and the new experiments.