### PR TITLE
Fix License to actually declare copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Educational Testing Service.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Discovered missing when comparing to output of the `lice` tool.

part of JOSS review:
https://github.com/openjournals/joss-reviews/issues/33