### PR TITLE
Pep8

### DIFF
--- a/rsmtool/analysis.py
+++ b/rsmtool/analysis.py
@@ -10,6 +10,7 @@ from sklearn.metrics import r2_score
 
 from rsmtool.utils import agreement, partial_correlations
 
+
 def compute_basic_descriptives(df, selected_features):
     """
     Compute basic descriptive statistics for the columns
@@ -255,6 +256,7 @@ def correlation_helper(df,
             df_target_partcors,
             df_target_partcors_no_length)
 
+
 def compute_correlations_by_group(df,
                                   selected_features,
                                   target_variable,
@@ -412,8 +414,8 @@ def metrics_helper(human_scores, system_scores):
     # compute the agreement statistics
     human_system_agreement = agreement(human_scores, system_scores)
     human_system_adjacent_agreement = agreement(human_scores,
-                                             system_scores,
-                                             tolerance=1)
+                                                system_scores,
+                                                tolerance=1)
 
     # compute the pearson correlation after removing
     # any cases where either of the scores are NaNs.
@@ -437,7 +439,7 @@ def metrics_helper(human_scores, system_scores):
     # compute standardized mean difference as recommended
     # by Williamson et al (2012)
     numerator = mean_system_score - mean_human_score
-    denominator = np.sqrt((system_score_sd**2 + human_score_sd**2)/2)
+    denominator = np.sqrt((system_score_sd**2 + human_score_sd**2) / 2)
     SMD = numerator/denominator
 
     # compute r2 and MSE
@@ -448,22 +450,22 @@ def metrics_helper(human_scores, system_scores):
     # return everything as a series
 
     metrics = pd.Series({'kappa': unweighted_kappa,
-                      'wtkappa': quadratic_weighted_kappa,
-                      'exact_agr': human_system_agreement,
-                      'adj_agr': human_system_adjacent_agreement,
-                      'SMD': SMD,
-                      'corr': correlations,
-                      'R2': r2,
-                      'RMSE': rmse,
-                      'sys_min': min_system_score,
-                      'sys_max': max_system_score,
-                      'sys_mean': mean_system_score,
-                      'sys_sd': system_score_sd,
-                      'h_min': min_human_score,
-                      'h_max': max_human_score,
-                      'h_mean': mean_human_score,
-                      'h_sd': human_score_sd,
-                      'N': len(system_scores)})
+                         'wtkappa': quadratic_weighted_kappa,
+                         'exact_agr': human_system_agreement,
+                         'adj_agr': human_system_adjacent_agreement,
+                         'SMD': SMD,
+                         'corr': correlations,
+                         'R2': r2,
+                         'RMSE': rmse,
+                         'sys_min': min_system_score,
+                         'sys_max': max_system_score,
+                         'sys_mean': mean_system_score,
+                         'sys_sd': system_score_sd,
+                         'h_min': min_human_score,
+                         'h_max': max_human_score,
+                         'h_mean': mean_human_score,
+                         'h_sd': human_score_sd,
+                         'N': len(system_scores)})
 
     return metrics
 
@@ -597,7 +599,7 @@ def compute_metrics(df,
                                                            'h_min', 'h_max',
                                                            'sys_mean', 'sys_sd',
                                                            'sys_min', 'sys_max',
-                                                           'corr','wtkappa', 'R2',
+                                                           'corr', 'wtkappa', 'R2',
                                                            'kappa', 'exact_agr',
                                                            'adj_agr', 'SMD', 'RMSE'])
         # rename `h_*` -> `h1_*` and `sys_*` -> `h2_*`
@@ -704,10 +706,10 @@ def compute_metrics_by_group(df_test,
         df_group = df_group.drop(grouping_variable, 1)
         (df_group_human_machine_metrics,
          df_group_human_machine_metrics_short,
-         df_group_human_human_metrics)  = compute_metrics(df_group,
-                                                          compute_shortened=True,
-                                                          use_scaled_predictions=use_scaled_predictions,
-                                                          include_second_score=include_second_score)
+         df_group_human_human_metrics) = compute_metrics(df_group,
+                                                         compute_shortened=True,
+                                                         use_scaled_predictions=use_scaled_predictions,
+                                                         include_second_score=include_second_score)
 
         # we need to convert the shortened data frame to a series here
         df_human_machine_eval_by_group[group] = df_group_human_machine_metrics_short.iloc[0]
@@ -808,7 +810,6 @@ def run_training_analyses(df_train_all,
     List of data frames, each containing a different
         analysis of the training set
     """
-
 
     # only use the features selected by the model but keep their order the same
     # as in the original file as ordering may affect the sign in pca
@@ -935,7 +936,6 @@ def run_prediction_analyses(df_test,
 
     assert len(df_preds.index) == len(df_test.index) == len(df_test_metadata.index)
 
-
     # set a general boolean flag indicating if
     # we should include the second human score
     include_second_score = not df_test_human_scores.empty
@@ -1004,9 +1004,10 @@ def run_prediction_analyses(df_test,
             df_confmatrix,
             df_score_dist)
 
+
 def analyze_excluded_responses(df, features, header,
-                              exclude_zero_scores=True,
-                              exclude_listwise=False):
+                               exclude_zero_scores=True,
+                               exclude_listwise=False):
     """
     Compute statistics on the responses that were excluded from
     analyses, either in the training set or in the test set.
@@ -1064,7 +1065,6 @@ def analyze_excluded_responses(df, features, header,
         # convert back to integers as these are all counts
         df_full_crosstab = df_full_crosstab.astype(int)
         df_full_crosstab.insert(0, header, df_full_crosstab.index)
-
 
     if not exclude_listwise:
         # if we are not excluding listwise, rename the first cell so that it is not set to zero
@@ -1128,8 +1128,8 @@ def analyze_used_responses(df_train, df_test, subgroups, candidate_column):
         train_candidates = set(df_train['candidate'])
         test_candidates = set(df_test['candidate'])
         df_analysis['candidates'] = [len(train_candidates), len(test_candidates),
-                                    len(train_candidates & test_candidates),
-                                    len(train_candidates | test_candidates)]
+                                     len(train_candidates & test_candidates),
+                                     len(train_candidates | test_candidates)]
 
         columns = ['partition', 'responses', 'candidates'] + subgroups
 
@@ -1231,7 +1231,6 @@ def run_data_composition_analyses_for_rsmtool(df_train_metadata,
     List of data frames, each containing a different
     data composition analysis
     """
-
 
     df_train_excluded_analysis = analyze_excluded_responses(df_train_excluded,
                                                             features,

--- a/rsmtool/create_features.py
+++ b/rsmtool/create_features.py
@@ -208,7 +208,8 @@ def generate_specs_from_data(feature_names,
     # get feature sign info if available
     if feature_sign:
         # Convert to dictionary {feature:sign}
-        sign_dict = dict(zip(feature_subset_specs.Feature, feature_subset_specs['Sign_'+feature_sign]))
+        sign_dict = dict(zip(feature_subset_specs.Feature,
+                             feature_subset_specs['Sign_{}'.format(feature_sign)]))
     # else create an empty dictionary
     else:
         sign_dict = {}

--- a/rsmtool/input.py
+++ b/rsmtool/input.py
@@ -32,6 +32,7 @@ if HAS_RSMEXTRA:
     from rsmextra.settings import (default_feature_subset_file,
                                    default_feature_sign)
 
+
 def select_candidates_with_N_or_more_items(df,
                                            N,
                                            candidate_column='candidate'):
@@ -72,9 +73,6 @@ def select_candidates_with_N_or_more_items(df,
 
     return (df_included,
             df_excluded)
-
-
-
 
 
 def locate_custom_sections(custom_report_section_paths, configpath):
@@ -146,7 +144,7 @@ def normalize_json_fields(json_obj):
                           'scale': 'use_scaled_predictions',
                           'feature.subset': 'feature_subset'}
 
-    model_name_mapping = {'empWt':'LinearRegression',
+    model_name_mapping = {'empWt': 'LinearRegression',
                           'eqWt': 'EqualWeightsLR',
                           'empWtBalanced': 'RebalancedLR',
                           'empWtDropNeg': '',
@@ -346,7 +344,7 @@ def validate_and_populate_json_fields(json_obj, context='rsmtool'):
     # and sign has not been specified in the config file
     if HAS_RSMEXTRA:
         if (new_json_obj['feature_subset_file'] == default_feature_subset_file
-            and not new_json_obj['sign']):
+                and not new_json_obj['sign']):
             new_json_obj['sign'] = default_feature_sign
 
     # 6. Check for fields that must be specified together
@@ -387,7 +385,6 @@ def process_json_fields(json_obj):
     -------
     ValueError
     """
-
 
     list_fields = ['feature_prefix',
                    'general_sections',
@@ -529,6 +526,7 @@ def normalize_and_validate_feature_file(feature_json):
                          "in the feature file: {}".format(duplicate_features))
 
     return new_json_obj
+
 
 def read_json_file(json_file):
     """
@@ -764,6 +762,7 @@ def check_flag_column(config_obj):
 
     return new_filtering_dict
 
+
 def check_feature_subset_file(feature_specs, subset=None, sign=None):
     """
     Check that the file is in the correct format and contains all
@@ -796,9 +795,9 @@ def check_feature_subset_file(feature_specs, subset=None, sign=None):
             raise ValueError("The subset columns in feature file can only contain 0 or 1")
 
     if sign:
-        if not 'Sign_'+sign in feature_specs.columns:
+        if not 'Sign_{}'.format(sign) in feature_specs.columns:
                 raise ValueError("The feature_subset_file does not contain the requested "
-                                 "sign column {}".format('Sign_'+sign))
+                                 "sign column 'Sign_{}'".format(sign))
 
         if not feature_specs[subset].isin(['-', '+']).all():
             raise ValueError("The sign columns in feature file can only contain - or +")
@@ -879,7 +878,7 @@ def load_experiment_data(main_config_file, output_dir):
     exclude_listwise = False
     min_items = config_obj['min_items_per_candidate']
     if min_items:
-        exclude_listwise=True
+        exclude_listwise = True
 
     # get the name of the model that we want to train and
     # check that it's valid
@@ -920,7 +919,7 @@ def load_experiment_data(main_config_file, output_dir):
     if custom_report_section_paths:
         logger.info('Locating custom report sections')
         custom_report_sections = locate_custom_sections(custom_report_section_paths,
-                                                         configpath)
+                                                        configpath)
     else:
         custom_report_sections = []
 
@@ -958,7 +957,6 @@ def load_experiment_data(main_config_file, output_dir):
     else:
         feature_subset_specs = None
 
-
     # Do we need to automatically find the best transformations/change sign?
     select_transformations = config_obj['select_transformations']
     feature_sign = config_obj['sign']
@@ -987,12 +985,12 @@ def load_experiment_data(main_config_file, output_dir):
     # check to make sure that `length_column` or `second_human_score_column`
     # are not also included in the requested features, if they are specified
     if (length_column and
-        length_column in requested_features):
+            length_column in requested_features):
         raise ValueError("The value of 'length_column' ('{}') cannot be "
                          "used as a model feature.".format(length_column))
 
     if (second_human_score_column and
-        second_human_score_column in requested_features):
+            second_human_score_column in requested_features):
         raise ValueError("The value of 'second_human_score_column' ('{}') cannot be "
                          "used as a model feature.".format(second_human_score_column))
 
@@ -1356,7 +1354,7 @@ def load_and_filter_data(csv_file,
     # ##ORIGINAL_NAME##.
     if (length_column and
         (len(df_filtered[df_filtered['length'].isnull()]) != 0 or
-             df_filtered['length'].std() <= 0)):
+            df_filtered['length'].std() <= 0)):
         logger.warning("The {} column either has missing values or a standard"
                        " deviation <= 0. No length-based analysis will be"
                        " provided. The column will be renamed as ##{}## and"
@@ -1417,7 +1415,7 @@ def load_and_filter_data(csv_file,
 
     # now extract all other columns and add 'spkitemid'
     other_columns = ['spkitemid'] + [column for column in df_filtered.columns
-                     if column not in not_other_columns]
+                                     if column not in not_other_columns]
     df_filtered_other_columns = df_filtered[other_columns]
 
     return (df_filtered_features,
@@ -1485,8 +1483,8 @@ def rename_default_columns(df,
     defaults = ['spkitemid', 'sc1', 'sc2', 'length', 'raw', 'candidate']
 
     # create a dictionary of name mapping for used columns
-    name_mapping = dict(filter(lambda t: t[0] !=None, zip(columns,
-                                                          defaults)))
+    name_mapping = dict(filter(lambda t: t[0] is not None, zip(columns,
+                                                               defaults)))
 
     # find the columns where the names match the default names
     columns_with_correct_default_names = [column for (column, default) in name_mapping.items()
@@ -1524,4 +1522,3 @@ def rename_default_columns(df,
                       inplace=True)
 
     return df
-

--- a/rsmtool/model.py
+++ b/rsmtool/model.py
@@ -103,12 +103,13 @@ def ols_coefficients_to_dataframe(coefs):
                                   'coefficient': coefs['const']}])
 
     # append the non-intercept frame to the intercept one
-    df_coef =  df_intercept.append(df_non_intercept, ignore_index=True)
+    df_coef = df_intercept.append(df_non_intercept, ignore_index=True)
 
     # we always want to have the feature column first
     df_coef = df_coef[['feature', 'coefficient']]
 
     return df_coef
+
 
 def skll_learner_params_to_dataframe(learner):
     """
@@ -150,7 +151,7 @@ def skll_learner_params_to_dataframe(learner):
                                   'coefficient': intercept}])
 
     # append the non-intercept frame to the intercept one
-    df_coef =  df_intercept.append(df_non_intercept, ignore_index=True)
+    df_coef = df_intercept.append(df_non_intercept, ignore_index=True)
 
     # we always want to have the feature column first
     df_coef = df_coef[['feature', 'coefficient']]
@@ -364,7 +365,7 @@ def train_builtin_model(model_name, df_train, experiment_id, csvdir, figdir):
         p_lambda = sqrt(len(df_train) * log10(len(feature_columns)))
 
         # create a SKLL FeatureSet instance from the given data frame
-        fs_train  = create_featureset_from_dataframe(df_train)
+        fs_train = create_featureset_from_dataframe(df_train)
 
         # note that 'alpha' in sklearn is different from this lambda
         # so we need to normalize looking at the sklearn objective equation
@@ -480,7 +481,7 @@ def train_builtin_model(model_name, df_train, experiment_id, csvdir, figdir):
         p_lambda = sqrt(len(df_train) * log10(len(feature_columns)))
 
         # create a SKLL FeatureSet instance from the given data frame
-        fs_train  = create_featureset_from_dataframe(df_train)
+        fs_train = create_featureset_from_dataframe(df_train)
 
         # note that 'alpha' in sklearn is different from this lambda
         # so we need to normalize looking at the sklearn objective equation
@@ -541,7 +542,7 @@ def train_builtin_model(model_name, df_train, experiment_id, csvdir, figdir):
         p_lambda = sqrt(len(df_train) * log10(len(feature_columns)))
 
         # create a SKLL FeatureSet instance from the given data frame
-        fs_train  = create_featureset_from_dataframe(df_train)
+        fs_train = create_featureset_from_dataframe(df_train)
 
         # note that 'alpha' in sklearn is different from this lambda
         # so we need to normalize looking at the sklearn objective equation
@@ -703,7 +704,7 @@ def train_model(model_name, df_train, experiment_id, csvdir, figdir):
     """
     call_args = [model_name, df_train, experiment_id, csvdir, figdir]
     model = train_builtin_model(*call_args) if model_name in builtin_models \
-             else train_skll_model(*call_args)
+        else train_skll_model(*call_args)
     return model
 
 
@@ -737,5 +738,3 @@ def check_model_name(model_name):
                          "check the spelling.".format(model_name))
 
     return model_type
-
-

--- a/rsmtool/predict.py
+++ b/rsmtool/predict.py
@@ -15,6 +15,7 @@ from skll import FeatureSet
 
 from rsmtool.preprocess import trim
 
+
 def predict_with_model(model, df):
     """
     Get the raw predictions of the given SKLL model on the data
@@ -59,6 +60,7 @@ def predict_with_model(model, df):
         df_predictions['sc1'] = labels
 
     return df_predictions
+
 
 def generate_train_and_test_predictions(model, df_train, df_test, trim_min, trim_max):
     """

--- a/rsmtool/preprocess.py
+++ b/rsmtool/preprocess.py
@@ -11,6 +11,7 @@ import logging
 import numpy as np
 import pandas as pd
 
+
 def trim(values, trim_min, trim_max):
     """
     Trim the values contained in the given numpy array to `trim_min` - 0.49998 as the floor and `trim_max` + 0.49998
@@ -323,7 +324,7 @@ def apply_inverse_transform(name, data, sd_multiplier=4):
                          "applied to feature {} where the values can"
                          "have different signs".format(name))
 
-    new_data =  1/data
+    new_data = 1 / data
     return new_data
 
 

--- a/rsmtool/report.py
+++ b/rsmtool/report.py
@@ -265,7 +265,7 @@ def determine_chosen_sections(general_sections,
         check_section_names(general_sections, 'general', context)
         chosen_general_sections = [s for s in general_sections
                                    if s in general_section_list]
-        all_general_sections=False
+        all_general_sections = False
 
     # 2. Exclude the subgroup sections if we do not have subgroup information.
 
@@ -287,7 +287,6 @@ def determine_chosen_sections(general_sections,
         # subgroup sections
         chosen_general_sections = [section for section in chosen_general_sections
                                    if not section in subgroup_sections]
-
 
     # 3. Include the specified (and valid) subset of the special sections
     chosen_special_sections = []
@@ -487,10 +486,10 @@ def create_report(experiment_id, description,
     os.environ['MODEL_TYPE'] = model_type
     os.environ['SCALED'] = '1' if use_scaled_predictions else '0'
     os.environ['EXCLUDE_ZEROS'] = '1' if exclude_zero_scores else '0'
-    os.environ['LENGTH_COLUMN'] = '' if length_column == None else length_column
-    os.environ['H2_COLUMN'] = '' if second_human_score_column == None else second_human_score_column
-    os.environ['MIN_ITEMS'] = '0' if min_items_per_candidate == None else str(min_items_per_candidate)
-    os.environ['FEATURE_SUBSET_FILE'] = '' if feature_subset_file == None else feature_subset_file
+    os.environ['LENGTH_COLUMN'] = '' if length_column is None else length_column
+    os.environ['H2_COLUMN'] = '' if second_human_score_column is None else second_human_score_column
+    os.environ['MIN_ITEMS'] = '0' if min_items_per_candidate is None else str(min_items_per_candidate)
+    os.environ['FEATURE_SUBSET_FILE'] = '' if feature_subset_file is None else feature_subset_file
 
     # we define separate groups to allow future flexibility in defining
     # what groups are used for descriptives and evaluations

--- a/rsmtool/rsmcompare.py
+++ b/rsmtool/rsmcompare.py
@@ -102,7 +102,7 @@ def run_comparison(config_file, output_dir):
     if custom_report_section_paths:
         logger.info('Locating custom report sections')
         custom_report_sections = locate_custom_sections(custom_report_section_paths,
-                                                         configpath)
+                                                        configpath)
     else:
         custom_report_sections = []
 
@@ -125,6 +125,7 @@ def run_comparison(config_file, output_dir):
                              chosen_notebook_files,
                              use_scaled_predictions_old=use_scaled_predictions_old,
                              use_scaled_predictions_new=use_scaled_predictions_new)
+
 
 def main():
 

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -134,7 +134,7 @@ def run_evaluation(config_file, output_dir):
     exclude_listwise = False
     min_items_per_candidate = config_obj['min_items_per_candidate']
     if min_items_per_candidate:
-        exclude_listwise=True
+        exclude_listwise = True
 
     general_report_sections = config_obj['general_sections']
 
@@ -189,11 +189,11 @@ def run_evaluation(config_file, output_dir):
     #                  'scale', 'scale_trim' and 'scale_trim_round'.
 
     # we need to scale if and only if a CSV file is specified
-    do_scaling = (scale_with != None and scale_with != 'asis')
+    do_scaling = (scale_with is not None and scale_with != 'asis')
 
     # use scaled predictions for the analyses unless
     # we were told not to
-    use_scaled_predictions = (scale_with != None)
+    use_scaled_predictions = (scale_with is not None)
 
     # log an appropriate message
     if scale_with is None:
@@ -282,7 +282,6 @@ def run_evaluation(config_file, output_dir):
                                              'raw',
                                              'spkitemid',
                                              exclude_zeros=False)
-
 
     del df_filtered
     df_filtered_pred = newdf
@@ -554,4 +553,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -34,6 +34,7 @@ from rsmtool.utils import LogFormatter
 from skll import Learner
 from rsmtool.version import __version__
 
+
 def compute_and_save_predictions(config_file, output_file, feats_file):
     """
     Run ``rsmpredict`` with given configuration file and generate
@@ -177,8 +178,6 @@ def compute_and_save_predictions(config_file, output_file, feats_file):
     # check that the id_column contains unique values
     if df_input['spkitemid'].size != df_input['spkitemid'].unique().size:
         raise ValueError("The data contains repeated response IDs in {}. Please make sure all response IDs are unique and re-run the tool.".format(id_column))
-
-
 
     # now we need to pre-process these features using
     # the parameters that are already stored in the
@@ -370,4 +369,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -32,6 +32,7 @@ from rsmtool.utils import (scale_coefficients,
 from rsmtool.utils import LogFormatter
 from rsmtool.version import __version__
 
+
 def run_experiment(config_file, output_dir):
     """
     Run RSMTool experiment using the given configuration
@@ -253,9 +254,9 @@ def run_experiment(config_file, output_dir):
                                 reset_index=True)
 
         length_marg_cors, length_part_cors, _ = length_correlation_by_group_dict.get(group,
-                                                                                  (pd.DataFrame(),
-                                                                                   pd.DataFrame(),
-                                                                                   pd.DataFrame()))
+                                                                                     (pd.DataFrame(),
+                                                                                      pd.DataFrame(),
+                                                                                      pd.DataFrame()))
         write_experiment_output([length_marg_cors, length_part_cors],
                                 ['margcor_length_by_{}'.format(group),
                                  'pcor_length_by_{}'.format(group)],
@@ -270,7 +271,7 @@ def run_experiment(config_file, output_dir):
     # Tell the user that they will get the mismatch warning if
     # the model features do not match the original data
 
-    if len(selected_features) != len(df_test_preprocessed_features.columns)-2:
+    if len(selected_features) != len(df_test_preprocessed_features.columns) - 2:
         logger.warning("You specified a model with automatic feature "
                        "selection and therefore some of the original "
                        "features were excluded from the final model. If this "
@@ -389,6 +390,7 @@ def run_experiment(config_file, output_dir):
                   exclude_zero_scores=exclude_zero_scores,
                   use_scaled_predictions=use_scaled_predictions)
 
+
 def main():
 
     # set up the basic logging config
@@ -458,4 +460,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -113,6 +113,7 @@ def do_run_comparison(source, config_file):
     experiment_dir = join(source_output_dir, source)
     run_comparison(config_file, experiment_dir)
 
+
 def check_csv_output(csv1, csv2):
     """
     Check if two experiment CSV files have values that are
@@ -150,7 +151,7 @@ def check_csv_output(csv1, csv2):
     if csv1.endswith('pca.csv') or csv1.endswith('factor_correlations.csv'):
         for df in [df1, df2]:
             msk = df.dtypes == np.float64
-            df.loc[:,msk] = df.loc[:,msk].abs()
+            df.loc[:, msk] = df.loc[:, msk].abs()
 
     assert_frame_equal(df1.sort_index(axis=1),
                        df2.sort_index(axis=1),
@@ -191,9 +192,9 @@ def check_scaled_coefficients(source, experiment_id):
         The experiment ID.
     """
     preprocessed_test_file = join('test_outputs',
-                                   source,
-                                   'output',
-                                   '{}_test_preprocessed_features.csv'.format(experiment_id))
+                                  source,
+                                  'output',
+                                  '{}_test_preprocessed_features.csv'.format(experiment_id))
     scaled_coefficients_file = join('test_outputs',
                                     source,
                                     'output',

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -16,9 +16,9 @@ package_path = os.path.dirname(__file__)
 # Adapted from: http://stackoverflow.com/questions/1343227/can-pythons-logging-format-be-modified-depending-on-the-message-log-level
 class LogFormatter(logging.Formatter):
 
-    err_fmt  = "ERROR: %(msg)s"
+    err_fmt = "ERROR: %(msg)s"
     warn_fmt = "WARNING: %(msg)s"
-    dbg_fmt  = "DBG: %(module)s: %(lineno)d: %(msg)s"
+    dbg_fmt = "DBG: %(module)s: %(lineno)d: %(msg)s"
     info_fmt = "%(msg)s"
 
     def __init__(self, fmt="%(levelno)s: %(msg)s"):
@@ -81,7 +81,7 @@ def covariance_to_correlation(m):
     if not numrows == numcols:
         raise ValueError('Input matrix must be square')
 
-    Is = np.sqrt(1/np.diag(m))
+    Is = np.sqrt(1 / np.diag(m))
     retval = Is * m * np.repeat(Is, numrows).reshape(numrows, numrows)
     np.fill_diagonal(retval, 1.0)
     return retval
@@ -158,7 +158,7 @@ def agreement(score1, score2, tolerance=0):
     # are for the same number of items
     assert len(score1) == len(score2)
 
-    num_agreements = sum([int(abs(s1-s2) <= tolerance)
+    num_agreements = sum([int(abs(s1 - s2) <= tolerance)
                           for s1, s2 in zip(score1, score2)])
 
     agreement_value = (float(num_agreements) / len(score1)) * 100
@@ -232,7 +232,7 @@ def write_feature_json(feature_specs,
     feature_specs_selected['features'] = [feature_info for feature_info in feature_specs['features'] if feature_info['feature'] in selected_features]
 
     makedirs(featuredir, exist_ok=True)
-    outjson = join(featuredir, experiment_id+'_selected.json')
+    outjson = join(featuredir, '{}_selected.json'.format(experiment_id))
     with open(outjson, 'w') as outfile:
         json.dump(feature_specs_selected, outfile, indent=4, separators=(',', ': '))
 


### PR DESCRIPTION
pep8 1.4.6 run with  --ignore=E501 

Ignored issues (full list below):
1. No white space around the highest priority arithmetic operators in complex expression
2. Overindentation for continuation line in multi-line construct: as far as I could tell PEP8 has no explicit position on such cases but specifies that 4 space rule is optional for continuation lines. The current indentation makes the code easier to read than the 4 space indent. 

rsmtool/analysis.py:442:43: E226 missing whitespace around arithmetic operator
rsmtool/analysis.py:442:63: E226 missing whitespace around arithmetic operator
rsmtool/analysis.py:443:20: E226 missing whitespace around arithmetic operator
rsmtool/model.py:343:85: E226 missing whitespace around arithmetic operator
rsmtool/preprocess.py:435:17: E226 missing whitespace around arithmetic operator
rsmtool/report.py:306:23: E127 continuation line over-indented for visual indent
rsmtool/report.py:307:23: E127 continuation line over-indented for visual indent
rsmtool/utils.py:275:47: E226 missing whitespace around arithmetic operator
rsmtool/utils.py:279:39: E226 missing whitespace around arithmetic operator
rsmtool/utils.py:279:99: E226 missing whitespace around arithmetic operator