### PR TITLE
Fix the loading of Javascript sorting library in header notebooks.

### DIFF
--- a/rsmtool/notebooks/comparison/header.ipynb
+++ b/rsmtool/notebooks/comparison/header.ipynb
@@ -164,7 +164,8 @@
    },
    "outputs": [],
    "source": [
-    "display(Javascript(filename=join(javascript_path, \"sort.js\")))"
+    "with open(join(javascript_path, \"sort.js\"), \"r\", encoding=\"utf-8\") as sortf:\n",
+    "    display(Javascript(data=sortf.read()))"
    ]
   },
   {

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -150,7 +150,8 @@
    },
    "outputs": [],
    "source": [
-    "display(Javascript(filename=join(javascript_path, \"sort.js\")))"
+    "with open(join(javascript_path, \"sort.js\"), \"r\", encoding=\"utf-8\") as sortf:\n",
+    "    display(Javascript(data=sortf.read()))"
    ]
   },
   {

--- a/rsmtool/report.py
+++ b/rsmtool/report.py
@@ -70,7 +70,7 @@ package_path = dirname(__file__)
 notebook_path = abspath(join(package_path, 'notebooks'))
 template_path = join(notebook_path, 'templates')
 javascript_path = join(notebook_path, 'javascript')
-comparison_notebook_path = join(notebook_path, 'comparison'))
+comparison_notebook_path = join(notebook_path, 'comparison')
 
 # Define the general section list
 
@@ -541,7 +541,7 @@ def create_comparison_report(experiment_id_old, description_old,
     os.environ['FIGURE_DIR_NEW'] = figdir_new
     os.environ['SCALED_NEW'] = '1' if use_scaled_predictions_new else '0'
     os.environ['JAVASCRIPT_PATH'] = javascript_path
-    
+
     # we define separate groups to allow future flexibility in defining
     # what groups are used for descriptives and evaluations
     os.environ['GROUPS_FOR_DESCRIPTIVES'] = '%%'.join(subgroups)

--- a/rsmtool/report.py
+++ b/rsmtool/report.py
@@ -69,10 +69,8 @@ else:
 package_path = dirname(__file__)
 notebook_path = abspath(join(package_path, 'notebooks'))
 template_path = join(notebook_path, 'templates')
-javascript_path = join(package_path, 'notebooks', 'javascript')
-comparison_notebook_path = abspath(join(package_path,
-                                        'notebooks',
-                                        'comparison'))
+javascript_path = join(notebook_path, 'javascript')
+comparison_notebook_path = join(notebook_path, 'comparison'))
 
 # Define the general section list
 


### PR DESCRIPTION
- Use `notebook_path` in `report.py` when constructing new paths.
- Explicitly read `javascript/sort.js` in both header notebooks to get around weird encoding issues in RSMApp.