### PR TITLE
Fix CircleCI builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
     - "~/miniconda3/pkgs"
   override:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - pushd ${HOME}/miniconda3/pkgs && find -maxdepth 1 -mindepth 1 -type d | xargs rm -rf && popd
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -f
     - ${HOME}/miniconda3/bin/conda config --add channels desilinguist
@@ -23,4 +24,3 @@ test:
     - ${HOME}/miniconda3/bin/nosetests -v tests --with-coverage --cover-package=rsmtool --cov-config .coveragerc
   post:
     - cd ${HOME}/rsmtool && ${HOME}/miniconda3/bin/coveralls
-    - pushd ${HOME}/miniconda3/pkgs && find -maxdepth 1 -mindepth 1 -type d | xargs rm -rf && popd

--- a/circle.yml
+++ b/circle.yml
@@ -14,13 +14,13 @@ dependencies:
     - ./miniconda.sh -b -f
     - ${HOME}/miniconda3/bin/conda config --add channels desilinguist
     - ${HOME}/miniconda3/bin/conda update --yes conda
-    - ${HOME}/miniconda3/bin/conda install --file conda_requirements.txt --yes
-    - ${HOME}/miniconda3/bin/pip install nose-cov python-coveralls
-    - ${HOME}/miniconda3/bin/pip install -e .
+    - ${HOME}/miniconda3/bin/conda create --name rsmenv --file conda_requirements.txt --yes
+    - ${HOME}/miniconda3/envs/rsmenv/bin/pip install nose-cov python-coveralls
+    - ${HOME}/miniconda3/envs/rsmenv/bin/pip install -e .
 
 # Run test
 test:
   override:
-    - ${HOME}/miniconda3/bin/nosetests -v tests --with-coverage --cover-package=rsmtool --cov-config .coveragerc
+    - ${HOME}/miniconda3/envs/rsmenv/bin/nosetests -v tests --with-coverage --cover-package=rsmtool --cov-config .coveragerc
   post:
-    - cd ${HOME}/rsmtool && ${HOME}/miniconda3/bin/coveralls
+    - cd ${HOME}/rsmtool && ${HOME}/miniconda3/envs/rsmenv/bin/coveralls

--- a/circle.yml
+++ b/circle.yml
@@ -23,3 +23,4 @@ test:
     - ${HOME}/miniconda3/bin/nosetests -v tests --with-coverage --cover-package=rsmtool --cov-config .coveragerc
   post:
     - cd ${HOME}/rsmtool && ${HOME}/miniconda3/bin/coveralls
+    - pushd ${HOME}/miniconda3/pkgs && find -maxdepth 1 -mindepth 1 -type d | xargs rm -rf && popd


### PR DESCRIPTION
The latest version of `miniconda` apparently does two things differently now:
- it unzips packages and leaves those directories under `pkgs`. Since we explicitly cache `pkgs` to ensure fast builds, the existing directories cause conflicts. I guess previously it was ignoring existing directories. 
- it now installs packages in the root conda environment that are _not_ available for python 3.4 at all which causes problems when we use the root environment for installing rsmtool. We now create an entirely new environment (`rsmenv`) and use that instead of the root environment.