### PR TITLE
Bugfix/#137 wrong file path

### DIFF
--- a/rsmtool/reader.py
+++ b/rsmtool/reader.py
@@ -65,8 +65,9 @@ class DataReader:
         assert len(filepaths) == len(framenames)
 
         # Make sure that there are no Nones in the filepaths
-        frames_with_no_path = [framenames[i] for i in range(len(framenames)) if filepaths[i] is None]
-        if len(frames_with_no_path) > 0:
+        
+        if None in filepaths:
+            frames_with_no_path = [framenames[i] for i in range(len(framenames)) if filepaths[i] is None]
             raise ValueError("No path specified for {}".format(' ,'.join(frames_with_no_path)))
 
         # Assign names and paths lists

--- a/rsmtool/reader.py
+++ b/rsmtool/reader.py
@@ -54,6 +54,8 @@ class DataReader:
             If any elements in file_converters are not dict.
         NameError
             If file converter name does not exist in the dataset.
+        ValueError
+            If filepath for a given file is None
         """
 
         # Default datasets list
@@ -61,6 +63,11 @@ class DataReader:
 
         # Make sure filepaths length matches frame names length
         assert len(filepaths) == len(framenames)
+
+        # Make sure that there are no Nones in the filepaths
+        frames_with_no_path = [framenames[i] for i in range(len(framenames)) if filepaths[i] is None]
+        if len(frames_with_no_path) > 0:
+            raise ValueError("No path specified for {}".format(' ,'.join(frames_with_no_path)))
 
         # Assign names and paths lists
         self.dataset_names = framenames

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -97,13 +97,27 @@ def run_experiment(config_file_or_obj,
     writer = DataWriter(configuration['experiment_id'])
 
     # Get the paths and names for the DataReader
-    (file_names,
-     file_paths) = configuration.get_names_and_paths(['train_file', 'test_file',
-                                                      'features', 'feature_subset_file'],
-                                                     ['train', 'test', 'feature_specs',
-                                                      'feature_subset_specs'])
 
-    file_paths = DataReader.locate_files(file_paths, configpath)
+    (file_names,
+     file_paths_org) = configuration.get_names_and_paths(['train_file', 'test_file',
+                                                          'features', 'feature_subset_file'],
+                                                         ['train', 'test', 'feature_specs',
+                                                          'feature_subset_specs'])
+
+    file_paths = DataReader.locate_files(file_paths_org, configpath)
+
+    # check that we were able to locate all files
+    if None in file_paths:
+        indices_with_no_paths = [i for i in range(len(file_paths))
+                                 if file_paths[i] is None]
+
+        error_message_list = ["{} file {} not found.".format(file_names[i],
+                                                             file_paths_org[i])
+                              for i in indices_with_no_paths]
+
+        raise FileNotFoundError('\n'.join(error_message_list))
+
+
 
     # Use the default converter for both train and test
     converters = {'train': configuration.get_default_converter(),

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -107,17 +107,14 @@ def run_experiment(config_file_or_obj,
     file_paths = DataReader.locate_files(file_paths_org, configpath)
 
     # check that we were able to locate all files
+
     if None in file_paths:
         indices_with_no_paths = [i for i in range(len(file_paths))
                                  if file_paths[i] is None]
 
-        error_message_list = ["{} file {} not found.".format(file_names[i],
-                                                             file_paths_org[i])
-                              for i in indices_with_no_paths]
-
-        raise FileNotFoundError('\n'.join(error_message_list))
-
-
+        missing_file_paths = [file_paths_org[i] for i in indices_with_no_paths]
+    
+        raise FileNotFoundError('The following files were not found: {}'.format(repr(missing_file_paths)))
 
     # Use the default converter for both train and test
     converters = {'train': configuration.get_default_converter(),

--- a/tests/data/experiments/lr-wrong-path-features/lr.json
+++ b/tests/data/experiments/lr-wrong-path-features/lr.json
@@ -1,0 +1,14 @@
+{
+    "train_file": "../../files/train.csv",
+    "id_column": "ID",
+    "use_scaled_predictions": true,
+    "test_label_column": "score",
+    "train_label_column": "score",
+    "test_file": "../../files/test.csv",
+    "trim_max": 6,
+    "features": "features.csv",
+    "trim_min": 1,
+    "model": "LinearRegression",
+    "experiment_id": "lr",
+    "description": "Using all features with an LinearRegression model."
+}

--- a/tests/data/experiments/lr-wrong-path/features.csv
+++ b/tests/data/experiments/lr-wrong-path/features.csv
@@ -1,0 +1,9 @@
+feature,sign,transform
+FEATURE1,1,raw
+FEATURE2,1,raw
+FEATURE3,1,raw
+FEATURE4,1,raw
+FEATURE5,1,raw
+FEATURE6,1,raw
+FEATURE7,1,raw
+FEATURE8,1,raw

--- a/tests/data/experiments/lr-wrong-path/lr.json
+++ b/tests/data/experiments/lr-wrong-path/lr.json
@@ -1,0 +1,14 @@
+{
+    "train_file": "../files/train.csv",
+    "id_column": "ID",
+    "use_scaled_predictions": true,
+    "test_label_column": "score",
+    "train_label_column": "score",
+    "test_file": "../../files/test.csv",
+    "trim_max": 6,
+    "features": "features.csv",
+    "trim_min": 1,
+    "model": "LinearRegression",
+    "experiment_id": "lr",
+    "description": "Using all features with an LinearRegression model."
+}

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -507,6 +507,22 @@ def test_run_experiment_eval_lr_with_missing_candidate_column():
     do_run_evaluation(source, experiment_id, config_file)
 
 
+@raises(FileNotFoundError)
+def test_run_experiment_lr_eval_wrong_path():
+
+    # basic rsmeval experiment with wrong path to the 
+    # predictions file
+
+    source = 'lr-eval-with-wrong-path'
+    experiment_id = 'lr_eval_with_h2'
+    config_file = join(test_dir,
+                       'data',
+                       'experiments',
+                       source,
+                       '{}.json'.format(experiment_id))
+    do_run_evaluation(source, experiment_id, config_file)
+
+
 def test_run_experiment_lr_eval_with_cfg():
 
     # basic evaluation experiment using rsmeval

--- a/tests/test_experiment_rsmtool.py
+++ b/tests/test_experiment_rsmtool.py
@@ -1788,6 +1788,35 @@ def test_run_experiment_lr_feature_json():
         do_run_experiment(source, experiment_id, config_file)
 
 
+@raises(FileNotFoundError)
+def test_run_experiment_wrong_train_file_path():
+    # basic experiment with the path in train_file field pointing to 
+    # a non-existing file
+    source = 'lr-wrong-path'
+    experiment_id = 'lr'
+    config_file = join(test_dir,
+                       'data',
+                       'experiments',
+                        source,
+                       '{}.json'.format(experiment_id))
+    do_run_experiment(source, experiment_id, config_file)
+
+
+@raises(FileNotFoundError)
+def test_run_experiment_wrong_feature_file_path():
+    # basic experiment with the path in features field pointing to 
+    # a non-existing file
+    source = 'lr-wrong-path-features'
+    experiment_id = 'lr'
+    config_file = join(test_dir,
+                       'data',
+                       'experiments',
+                        source,
+                       '{}.json'.format(experiment_id))
+    do_run_experiment(source, experiment_id, config_file)
+
+
+
 def test_run_experiment_lr_with_cfg():
     # basic experiment with a LinearRegression model
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -236,3 +236,12 @@ class TestDataReader:
         paths = {'file1.csv', 'file2.xlsx'}
         config_dir = 'output'
         DataReader.locate_files(paths, config_dir)
+
+
+    @raises(ValueError)
+    def test_setup_none_in_path(self):
+        paths = ['path1.csv', None, 'path2.csv']
+        framenames = ['train', 'test', 'features']
+        reader = DataReader(paths, framenames)
+
+


### PR DESCRIPTION
* Added error capture/error message when configuration file specifies path to a non-existing file
* Added an extra check to the DataReader to make sure the paths passed to the reader are not None (Nones usually emerge when `locate_file` was not able to locate the file)