### PR TITLE
Adding DataWriter to header notebooks

### DIFF
--- a/rsmtool/notebooks/comparison/header.ipynb
+++ b/rsmtool/notebooks/comparison/header.ipynb
@@ -50,8 +50,8 @@
     "\n",
     "from rsmtool.comparer import Comparer\n",
     "\n",
-    "#(load_rsmtool_output,\n",
-    "#compute_correlations_between_versions)\n",
+    "from rsmtool.reader import DataReader\n",
+    "from rsmtool.writer import DataWriter\n",
     "\n",
     "from rsmtool.utils import (float_format_func,\n",
     "                           int_or_float_format_func,\n",
@@ -405,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -49,6 +49,7 @@
     "from IPython import sys_info\n",
     "from IPython.display import display, HTML, Image, Javascript, Markdown, SVG\n",
     "from rsmtool.reader import DataReader\n",
+    "from rsmtool.writer import DataWriter\n",
     "from rsmtool.utils import (float_format_func,\n",
     "                           int_or_float_format_func,\n",
     "                           compute_subgroup_plot_params,\n",
@@ -357,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/rsmtool/notebooks/summary/header.ipynb
+++ b/rsmtool/notebooks/summary/header.ipynb
@@ -57,6 +57,7 @@
     "                           show_thumbnail)\n",
     "\n",
     "from rsmtool.reader import DataReader\n",
+    "from rsmtool.writer import DataWriter\n",
     "from rsmtool.version import VERSION as rsmtool_version"
    ]
   },
@@ -243,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
People may want to write custom notebooks that output new files in various formats, so I'm adding `DataWriter` as an import in the `header.ipynb` notebooks. Let's try to merge this before #153, if possible.