### PR TITLE
Allow dictionary to to be passed to `DataWriter` `write_experiment_output()` method

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -52,6 +52,44 @@ class TestDataWriter:
         assert_frame_equal(container.dataset1, ds_1_csv)
         assert_frame_equal(container.dataset1, ds_1_xls)
 
+    def test_dictionary_save_files(self):
+
+        data_sets = {'dataset1': pd.DataFrame(np.random.normal(size=(100, 2)),
+                                              columns=['A', 'B']),
+                     'dataset2': pd.DataFrame(np.random.normal(size=(120, 3)),
+                                              columns=['A', 'B', 'C'])}
+
+        directory = 'temp_directory'
+        os.makedirs(directory, exist_ok=True)
+
+        writer = DataWriter()
+        for file_type in ['json', 'csv', 'xlsx']:
+
+            if file_type != 'json':
+
+                writer.write_experiment_output(directory,
+                                               data_sets,
+                                               dataframe_names=['dataset1'],
+                                               file_format=file_type)
+            else:
+                writer.write_experiment_output(directory,
+                                               data_sets,
+                                               new_names_dict={'dataset1': 'aaa'},
+                                               dataframe_names=['dataset1'],
+                                               file_format=file_type)
+
+        aaa_json = pd.read_json(os.path.join(directory, 'aaa.json'))
+        ds_1_csv = pd.read_csv(os.path.join(directory, 'dataset1.csv'))
+        ds_1_xls = pd.read_excel(os.path.join(directory, 'dataset1.xlsx'))
+
+        output_dir = os.listdir(directory)
+        rmtree(directory)
+        assert sorted(output_dir) == sorted(['aaa.json', 'dataset1.csv', 'dataset1.xlsx'])
+
+        assert_frame_equal(data_sets['dataset1'], aaa_json)
+        assert_frame_equal(data_sets['dataset1'], ds_1_csv)
+        assert_frame_equal(data_sets['dataset1'], ds_1_xls)
+
     @raises(KeyError)
     def test_data_container_save_wrong_format(self):
 
@@ -111,41 +149,3 @@ class TestDataWriter:
         assert_frame_equal(container.dataset1, aaa_json)
         assert_frame_equal(container.dataset1, ds_1_csv)
         assert_frame_equal(container.dataset1, ds_1_xls)
-
-    def test_dictionary_save_files(self):
-
-        data_sets = {'dataset1': pd.DataFrame(np.random.normal(size=(100, 2)),
-                                              columns=['A', 'B']),
-                     'dataset2': pd.DataFrame(np.random.normal(size=(120, 3)),
-                                              columns=['A', 'B', 'C'])}
-
-        directory = 'temp_directory'
-        os.makedirs(directory, exist_ok=True)
-
-        writer = DataWriter()
-        for file_type in ['json', 'csv', 'xlsx']:
-
-            if file_type != 'json':
-
-                writer.write_experiment_output(directory,
-                                               data_sets,
-                                               dataframe_names=['dataset1'],
-                                               file_format=file_type)
-            else:
-                writer.write_experiment_output(directory,
-                                               data_sets,
-                                               new_names_dict={'dataset1': 'aaa'},
-                                               dataframe_names=['dataset1'],
-                                               file_format=file_type)
-
-        aaa_json = pd.read_json(os.path.join(directory, 'aaa.json'))
-        ds_1_csv = pd.read_csv(os.path.join(directory, 'dataset1.csv'))
-        ds_1_xls = pd.read_excel(os.path.join(directory, 'dataset1.xlsx'))
-
-        output_dir = os.listdir(directory)
-        rmtree(directory)
-        assert sorted(output_dir) == sorted(['aaa.json', 'dataset1.csv', 'dataset1.xlsx'])
-
-        assert_frame_equal(data_sets['dataset1'], aaa_json)
-        assert_frame_equal(data_sets['dataset1'], ds_1_csv)
-        assert_frame_equal(data_sets['dataset1'], ds_1_xls)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -45,7 +45,6 @@ class TestDataWriter:
         ds_1_xls = pd.read_excel(os.path.join(directory, 'dataset1.xlsx'))
 
         output_dir = os.listdir(directory)
-        print(output_dir)
         rmtree(directory)
         assert sorted(output_dir) == sorted(['aaa.json', 'dataset1.csv', 'dataset1.xlsx'])
 
@@ -104,7 +103,6 @@ class TestDataWriter:
         ds_1_xls = pd.read_excel(os.path.join(directory, 'test_dataset1.xlsx'))
 
         output_dir = os.listdir(directory)
-        print(output_dir)
         rmtree(directory)
         assert sorted(output_dir) == sorted(['test_aaa.json',
                                              'test_dataset1.csv',
@@ -113,3 +111,41 @@ class TestDataWriter:
         assert_frame_equal(container.dataset1, aaa_json)
         assert_frame_equal(container.dataset1, ds_1_csv)
         assert_frame_equal(container.dataset1, ds_1_xls)
+
+    def test_dictionary_save_files(self):
+
+        data_sets = {'dataset1': pd.DataFrame(np.random.normal(size=(100, 2)),
+                                              columns=['A', 'B']),
+                     'dataset2': pd.DataFrame(np.random.normal(size=(120, 3)),
+                                              columns=['A', 'B', 'C'])}
+
+        directory = 'temp_directory'
+        os.makedirs(directory, exist_ok=True)
+
+        writer = DataWriter()
+        for file_type in ['json', 'csv', 'xlsx']:
+
+            if file_type != 'json':
+
+                writer.write_experiment_output(directory,
+                                               data_sets,
+                                               dataframe_names=['dataset1'],
+                                               file_format=file_type)
+            else:
+                writer.write_experiment_output(directory,
+                                               data_sets,
+                                               new_names_dict={'dataset1': 'aaa'},
+                                               dataframe_names=['dataset1'],
+                                               file_format=file_type)
+
+        aaa_json = pd.read_json(os.path.join(directory, 'aaa.json'))
+        ds_1_csv = pd.read_csv(os.path.join(directory, 'dataset1.csv'))
+        ds_1_xls = pd.read_excel(os.path.join(directory, 'dataset1.xlsx'))
+
+        output_dir = os.listdir(directory)
+        rmtree(directory)
+        assert sorted(output_dir) == sorted(['aaa.json', 'dataset1.csv', 'dataset1.xlsx'])
+
+        assert_frame_equal(data_sets['dataset1'], aaa_json)
+        assert_frame_equal(data_sets['dataset1'], ds_1_csv)
+        assert_frame_equal(data_sets['dataset1'], ds_1_xls)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,7 +21,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory'
+        directory = 'temp_directory_data_container_save_files'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter()
@@ -59,7 +59,7 @@ class TestDataWriter:
                      'dataset2': pd.DataFrame(np.random.normal(size=(120, 3)),
                                               columns=['A', 'B', 'C'])}
 
-        directory = 'temp_directory'
+        directory = 'temp_directory_dictionary_save_files'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter()
@@ -100,7 +100,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory'
+        directory = 'temp_directory_container_save_wrong_format'
 
         writer = DataWriter()
         writer.write_experiment_output(directory,
@@ -117,7 +117,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory'
+        directory = 'temp_directory_save_files_with_id'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter('test')

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,7 +21,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory_data_container_save_files'
+        directory = 'temp_directory_data_container_save_files_xyz'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter()
@@ -59,7 +59,7 @@ class TestDataWriter:
                      'dataset2': pd.DataFrame(np.random.normal(size=(120, 3)),
                                               columns=['A', 'B', 'C'])}
 
-        directory = 'temp_directory_dictionary_save_files'
+        directory = 'temp_directory_dictionary_save_files_xyz'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter()
@@ -100,7 +100,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory_container_save_wrong_format'
+        directory = 'temp_directory_container_save_wrong_format_xyz'
 
         writer = DataWriter()
         writer.write_experiment_output(directory,
@@ -117,7 +117,7 @@ class TestDataWriter:
 
         container = DataContainer(data_sets)
 
-        directory = 'temp_directory_save_files_with_id'
+        directory = 'temp_directory_save_files_with_id_xyz'
         os.makedirs(directory, exist_ok=True)
 
         writer = DataWriter('test')


### PR DESCRIPTION
In some cases, it may be useful to pass a dictionary to the `DataWriter` `write_experiment_output()` method, rather than having to instantiate a `DataContainer` object. 

This PR addresses issue #159. It also incorporates a new test to check that a `dict` can be passed to `write_experiment_output()`.