### PR TITLE
Allow specification of the tests directory via an environment variable

### DIFF
--- a/tests/test_experiment_rsmcompare.py
+++ b/tests/test_experiment_rsmcompare.py
@@ -1,3 +1,5 @@
+import os
+
 from os.path import join
 
 from nose.tools import raises
@@ -6,6 +8,9 @@ from parameterized import param, parameterized
 from rsmtool.test_utils import (check_run_comparison,
                                 do_run_comparison,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
+
 
 # set this to False to disable auto-updating of all experiment
 # tests contained in this file via `update_files.py`.
@@ -29,6 +34,8 @@ _AUTO_UPDATE = False
     param('lr-self-compare-with-subgroups-and-edge-cases', 'lr-subgroups-with-edge-cases_vs_lr-subgroups-with-edge-cases_report')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_comparison(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmcompare.py
+++ b/tests/test_experiment_rsmcompare.py
@@ -6,10 +6,15 @@ from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool.test_utils import (check_run_comparison,
-                                do_run_comparison,
-                                rsmtool_test_dir)
+                                do_run_comparison)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 # set this to False to disable auto-updating of all experiment

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -9,10 +9,15 @@ from parameterized import param, parameterized
 from rsmtool.test_utils import (check_file_output,
                                 check_report,
                                 check_run_evaluation,
-                                do_run_evaluation,
-                                rsmtool_test_dir)
+                                do_run_evaluation)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -1,3 +1,5 @@
+import os
+
 from glob import glob
 from os.path import basename, exists, join
 
@@ -9,6 +11,8 @@ from rsmtool.test_utils import (check_file_output,
                                 check_run_evaluation,
                                 do_run_evaluation,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
 
 
 @parameterized([
@@ -31,6 +35,8 @@ from rsmtool.test_utils import (check_file_output,
     param('lr-eval-with-continuous-human-scores', 'lr_eval_with_continuous_human_scores', consistency=True)
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_evaluation(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -1,3 +1,5 @@
+import os
+
 from glob import glob
 from os.path import basename, exists, join
 
@@ -12,6 +14,8 @@ from rsmtool.test_utils import (check_file_output,
                                 do_run_experiment,
                                 do_run_prediction,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
 
 
 @parameterized([
@@ -31,6 +35,8 @@ from rsmtool.test_utils import (check_file_output,
     param('svc-predict-expected-scores')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_prediction(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -12,10 +12,15 @@ from rsmtool.test_utils import (check_file_output,
                                 check_generated_output,
                                 check_run_prediction,
                                 do_run_experiment,
-                                do_run_prediction,
-                                rsmtool_test_dir)
+                                do_run_prediction)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmsummarize.py
+++ b/tests/test_experiment_rsmsummarize.py
@@ -11,10 +11,15 @@ from rsmtool.configuration_parser import ConfigurationParser
 from rsmtool.test_utils import (check_file_output,
                                 check_report,
                                 check_run_summary,
-                                do_run_summary,
-                                rsmtool_test_dir)
+                                do_run_summary)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmsummarize.py
+++ b/tests/test_experiment_rsmsummarize.py
@@ -1,3 +1,5 @@
+import os
+
 from glob import glob
 from os.path import basename, exists, join
 
@@ -12,6 +14,8 @@ from rsmtool.test_utils import (check_file_output,
                                 do_run_summary,
                                 rsmtool_test_dir)
 
+TEST_DIR = os.environ.get('TESTDIR', None)
+
 
 @parameterized([
     param('lr-self-summary'),
@@ -24,6 +28,8 @@ from rsmtool.test_utils import (check_file_output,
     param('lr-self-summary-no-scaling')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_summary(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmtool_1.py
+++ b/tests/test_experiment_rsmtool_1.py
@@ -1,3 +1,5 @@
+import os
+
 from os.path import join
 
 from nose.tools import raises
@@ -6,6 +8,8 @@ from parameterized import param, parameterized
 from rsmtool.test_utils import (check_run_experiment,
                                 do_run_experiment,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
 
 
 @parameterized([
@@ -29,6 +33,8 @@ from rsmtool.test_utils import (check_run_experiment,
     param('lr-with-continuous-human-scores-in-test', 'lr_with_continuous_human_scores_in_test', consistency=True)
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_experiment(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmtool_1.py
+++ b/tests/test_experiment_rsmtool_1.py
@@ -6,10 +6,15 @@ from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool.test_utils import (check_run_experiment,
-                                do_run_experiment,
-                                rsmtool_test_dir)
+                                do_run_experiment)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmtool_2.py
+++ b/tests/test_experiment_rsmtool_2.py
@@ -6,10 +6,15 @@ from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool.test_utils import (check_run_experiment,
-                                do_run_experiment,
-                                rsmtool_test_dir)
+                                do_run_experiment)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmtool_2.py
+++ b/tests/test_experiment_rsmtool_2.py
@@ -1,3 +1,5 @@
+import os
+
 from os.path import join
 
 from nose.tools import raises
@@ -6,6 +8,8 @@ from parameterized import param, parameterized
 from rsmtool.test_utils import (check_run_experiment,
                                 do_run_experiment,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
 
 
 @parameterized([
@@ -25,6 +29,8 @@ from rsmtool.test_utils import (check_run_experiment,
     param('lr-xlsx-input-and-subset-files', 'lr_xlsx_input_and_subset_files')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_experiment(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -13,10 +13,15 @@ from rsmtool.test_utils import (check_file_output,
                                 check_scaled_coefficients,
                                 check_generated_output,
                                 check_run_experiment,
-                                do_run_experiment,
-                                rsmtool_test_dir)
+                                do_run_experiment)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 from glob import glob
@@ -15,6 +16,8 @@ from rsmtool.test_utils import (check_file_output,
                                 do_run_experiment,
                                 rsmtool_test_dir)
 
+TEST_DIR = os.environ.get('TESTDIR', None)
+
 
 @parameterized([
     param('lr-no-standardization', 'lr_no_standardization'),
@@ -29,6 +32,8 @@ from rsmtool.test_utils import (check_file_output,
     param('lr-with-feature-list-and-transformation', 'lr_with_feature_list_and_transformation')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_experiment(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -1,3 +1,5 @@
+import os
+
 from os.path import join
 
 from nose.tools import raises
@@ -6,6 +8,8 @@ from parameterized import param, parameterized
 from rsmtool.test_utils import (check_run_experiment,
                                 do_run_experiment,
                                 rsmtool_test_dir)
+
+TEST_DIR = os.environ.get('TESTDIR', None)
 
 
 @parameterized([
@@ -38,6 +42,8 @@ from rsmtool.test_utils import (check_run_experiment,
     param('lr-with-length-string', 'lr_with_length_string')
 ])
 def test_run_experiment_parameterized(*args, **kwargs):
+    if TEST_DIR:
+        kwargs['given_test_dir'] = TEST_DIR
     check_run_experiment(*args, **kwargs)
 
 

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -6,10 +6,15 @@ from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool.test_utils import (check_run_experiment,
-                                do_run_experiment,
-                                rsmtool_test_dir)
+                                do_run_experiment)
 
+# allow test directory to be set via an environment variable
+# which is needed for package testing
 TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 @parameterized([


### PR DESCRIPTION
For package testing, we want to be able to run tests that are located outside of the package. This PR allows that.  To test that this works:

1. Check out `master` and `pip install -e .` that in a new conda environment (say `rsmenv`).
2. Check out this branch separately into a separate directory (say `$RSMNEWDIR`). Make some change to  `tests/data/experiments/lr/output/lr_betas.csv` but don't commit it.
3. Go to $HOME
4. Activate `rsmenv` and run `TESTDIR=$RSMNEWDIR nosetests --nologcapture $RSMNEWDIR/tests/test_experiment_rsmtool_1.py`. The `lr` experiment test should now fail. This tells us that the test data is now being used from the given `TESTDIR` instead of from the installed version of RSMTool in the environment.