### PR TITLE
Update `get_thumbnail_as_html()`

### DIFF
--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -786,7 +786,7 @@ def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
         be unique for each <img> tag.
     path_to_thumbnail : str or None, optional
         If you would like to use a different thumbnail
-        image, specify the path to the thumbnail.
+        image, specify the path to this thumbnail.
         Defaults to None.
 
     Returns

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -799,22 +799,24 @@ def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
     FileNotFoundError
         If the image file cannot be located.
     """
+    error_message = 'The file `{}` could not be located.'
     if not exists(path_to_image):
-        raise FileNotFoundError('The file `{}` could not be '
-                                'located.'.format(path_to_image))
+        raise FileNotFoundError(error_message.format(path_to_image))
 
     # check if the path is relative or absolute
     if isabs(path_to_image):
-        relative_path = relpath(path_to_image)
+        rel_image_path = relpath(path_to_image)
     else:
-        relative_path = path_to_image
+        rel_image_path = path_to_image
 
     # if `path_to_thumbnail` is None, use `path_to_image`;
     # otherwise, get the relative path to the thumbnail
     if path_to_thumbnail is None:
-        path_to_thumbnail = relative_path
+        rel_thumbnail_path = rel_image_path
     else:
-        path_to_thumbnail = relpath(path_to_thumbnail)
+        if not exists(path_to_thumbnail):
+            raise FileNotFoundError(error_message.format(path_to_thumbnail))
+        rel_thumbnail_path = relpath(path_to_thumbnail)
 
     # specify the thumbnail style
     style = """
@@ -841,8 +843,8 @@ def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
     image = ("""<img id='{}' src='{}' onclick='getPicture("{}")' """
              """title="Click to enlarge">"""
              """</img>""").format(image_id,
-                                  relative_path,
-                                  path_to_thumbnail)
+                                  rel_image_path,
+                                  rel_thumbnail_path)
 
     # create the image HTML
     image += style

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -812,7 +812,7 @@ def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
     # if `path_to_thumbnail` is None, use `path_to_image`;
     # otherwise, get the relative path to the thumbnail
     if path_to_thumbnail is None:
-        path_to_thumbnail = '{}'.format(relative_path)
+        path_to_thumbnail = relative_path
     else:
         path_to_thumbnail = relpath(path_to_thumbnail)
 
@@ -832,9 +832,8 @@ def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
     # on click, open larger image in new window
     script = """
     <script>
-    function getPicture(picid) {{
-        var src = $(picid).attr('src');
-        window.open(src, 'Image', resizable=1);
+    function getPicture(picpath) {{
+        window.open(picpath, 'Image', resizable=1);
     }};
     </script>""".format(image_id)
 

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -12,7 +12,6 @@ Utility classes and functions.
 import json
 import logging
 import re
-import os
 
 import numpy as np
 import pandas as pd
@@ -20,6 +19,7 @@ import pandas as pd
 from math import ceil
 from glob import glob
 from importlib import import_module
+from os.path import exists, isabs, join, relpath
 from pathlib import Path
 from string import Template
 from textwrap import wrap
@@ -716,7 +716,7 @@ def has_files_with_extension(directory, ext):
         True if directory contains files with given extension,
         else False.
     """
-    files_with_extension = glob(os.path.join(directory, '*.{}'.format(ext)))
+    files_with_extension = glob(join(directory, '*.{}'.format(ext)))
     return len(files_with_extension) > 0
 
 
@@ -768,7 +768,7 @@ def get_output_directory_extension(directory, experiment_id):
     return extension
 
 
-def get_thumbnail_as_html(path_to_image, image_id):
+def get_thumbnail_as_html(path_to_image, image_id, path_to_thumbnail=None):
     """
     Given an path to an image file, generate the HTML for
     a click-able thumbnail version of the image.
@@ -784,6 +784,10 @@ def get_thumbnail_as_html(path_to_image, image_id):
     image_id : int
         The id of the <img> tag in the HTML. This must
         be unique for each <img> tag.
+    path_to_thumbnail : str or None, optional
+        If you would like to use a different thumbnail
+        image, specify the path to the thumbnail.
+        Defaults to None.
 
     Returns
     -------
@@ -795,18 +799,22 @@ def get_thumbnail_as_html(path_to_image, image_id):
     FileNotFoundError
         If the image file cannot be located.
     """
-    if not os.path.exists(path_to_image):
+    if not exists(path_to_image):
         raise FileNotFoundError('The file `{}` could not be '
                                 'located.'.format(path_to_image))
 
     # check if the path is relative or absolute
-    if os.path.isabs(path_to_image):
-        relative_path = os.path.relpath(path_to_image)
+    if isabs(path_to_image):
+        relative_path = relpath(path_to_image)
     else:
         relative_path = path_to_image
 
-    # get the current ID of the image
-    image_id_with_pound = '"#{}"'.format(image_id)
+    # if `path_to_thumbnail` is None, use `path_to_image`;
+    # otherwise, get the relative path to the thumbnail
+    if path_to_thumbnail is None:
+        path_to_thumbnail = '{}'.format(relative_path)
+    else:
+        path_to_thumbnail = relpath(path_to_thumbnail)
 
     # specify the thumbnail style
     style = """
@@ -831,11 +839,11 @@ def get_thumbnail_as_html(path_to_image, image_id):
     </script>""".format(image_id)
 
     # generate image tags
-    image = ("""<img id='{}' src='{}' onclick='getPicture({})' """
+    image = ("""<img id='{}' src='{}' onclick='getPicture("{}")' """
              """title="Click to enlarge">"""
              """</img>""").format(image_id,
                                   relative_path,
-                                  image_id_with_pound)
+                                  path_to_thumbnail)
 
     # create the image HTML
     image += style
@@ -843,7 +851,7 @@ def get_thumbnail_as_html(path_to_image, image_id):
     return image
 
 
-def show_thumbnail(path_to_image, image_id):
+def show_thumbnail(path_to_image, image_id, path_to_thumbnail=None):
     """
     Given an path to an image file, display
     a click-able thumbnail version of the image.
@@ -859,13 +867,19 @@ def show_thumbnail(path_to_image, image_id):
     image_id : int
         The id of the <img> tag in the HTML. This must
         be unique for each <img> tag.
+    path_to_thumbnail : str or None, optional
+        If you would like to use a different thumbnail
+        image, specify the path to the thumbnail.
+        Defaults to None.
 
     Displays
     --------
     display : IPython.core.display.HTML
         The HTML display of the thumbnail image.
     """
-    display(HTML(get_thumbnail_as_html(path_to_image, image_id)))
+    display(HTML(get_thumbnail_as_html(path_to_image,
+                                       image_id,
+                                       path_to_thumbnail)))
 
 
 def get_files_as_html(output_dir, experiment_id, file_format, replace_dict={}):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -397,22 +397,31 @@ class TestThumbnail:
 
         # test FileNotFound error properly raised
 
-        path = 'random/path/to/figure1.svg'
+        path = 'random/path/asftesfa/to/figure1.svg'
         get_thumbnail_as_html(path, 1)
 
     def test_convert_to_html_with_different_thumbnail(self):
 
-        # test converting image to HTML with absolute path
+        # test converting image to HTML with different thumbnail
 
         path1 = relpath(join(test_dir, 'data', 'figures', 'figure1.svg'))
         path2 = relpath(join(test_dir, 'data', 'figures', 'figure2.svg'))
 
-        image = get_thumbnail_as_html(path1, 1, path2)
+        image = get_thumbnail_as_html(path1, 1, path_to_thumbnail=path2)
 
         clean_image = "".join(image.strip().split())
         clean_thumb = self.get_result(path1, other_path=path2)
 
         eq_(clean_image, clean_thumb)
+
+    @raises(FileNotFoundError)
+    def test_convert_to_html_thumbnail_not_found_error(self):
+
+        # test FileNotFound error properly raised for thumbnail
+
+        path1 = relpath(join(test_dir, 'data', 'figures', 'figure1.svg'))
+        path2 = 'random/path/asftesfa/to/figure1.svg'
+        image = get_thumbnail_as_html(path1, 1, path_to_thumbnail=path2)
 
 
 class TestExpectedScores():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -331,9 +331,8 @@ class TestThumbnail:
         </style>
 
         <script>
-        function getPicture(picid) {{
-            var src = $(picid).attr('src');
-            window.open(src, 'Image', resizable=1);
+        function getPicture(picpath) {{
+            window.open(picpath, 'Image', resizable=1);
         }};
         </script>""".format(id_num, path, other_path)
         return "".join(result.strip().split())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -308,13 +308,16 @@ class TestIntermediateFiles:
 
 class TestThumbnail:
 
-    def get_result(self, path, id_num='1'):
+    def get_result(self, path, id_num='1', other_path=None):
+
+        if other_path is None:
+            other_path = path
 
         # get the expected HTML output
 
         result = """
         <img id='{}' src='{}'
-        onclick='getPicture("#{}")'
+        onclick='getPicture("{}")'
         title="Click to enlarge">
         </img>
         <style>
@@ -332,7 +335,7 @@ class TestThumbnail:
             var src = $(picid).attr('src');
             window.open(src, 'Image', resizable=1);
         }};
-        </script>""".format(id_num, path, id_num)
+        </script>""".format(id_num, path, other_path)
         return "".join(result.strip().split())
 
     def test_convert_to_html(self):
@@ -397,6 +400,20 @@ class TestThumbnail:
 
         path = 'random/path/to/figure1.svg'
         get_thumbnail_as_html(path, 1)
+
+    def test_convert_to_html_with_different_thumbnail(self):
+
+        # test converting image to HTML with absolute path
+
+        path1 = relpath(join(test_dir, 'data', 'figures', 'figure1.svg'))
+        path2 = relpath(join(test_dir, 'data', 'figures', 'figure2.svg'))
+
+        image = get_thumbnail_as_html(path1, 1, path2)
+
+        clean_image = "".join(image.strip().split())
+        clean_thumb = self.get_result(path1, other_path=path2)
+
+        eq_(clean_image, clean_thumb)
 
 
 class TestExpectedScores():


### PR DESCRIPTION
This PR addresses #219. It updatse `get_thumbnail_as_html()` to add an optional `path_to_thumbnail` argument. There are cases where we may want to use separate thumbnail and full-sized images. If no `path_to_thumbnail` is passed, then the `path_to_image` argument will be used for both the thumbnail and full-sized image.