### PR TITLE
Add separate SMD function

### DIFF
--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -22,7 +22,9 @@ from sklearn.metrics import mean_squared_error
 from sklearn.metrics import r2_score
 
 from rsmtool.container import DataContainer
-from rsmtool.utils import agreement, partial_correlations, standardized_mean_difference
+from rsmtool.utils import (agreement,
+                           partial_correlations,
+                           standardized_mean_difference)
 
 
 class Analyzer:
@@ -665,7 +667,7 @@ class Analyzer:
         if not population_human_score_sd:
             population_human_score_sd = human_score_sd
 
-        # calculate the standardized mean difference
+        # calculate the (Williamson) standardized mean difference
         SMD = standardized_mean_difference(mean_system_score,
                                            mean_human_score,
                                            population_system_score_sd,

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -22,7 +22,7 @@ from sklearn.metrics import mean_squared_error
 from sklearn.metrics import r2_score
 
 from rsmtool.container import DataContainer
-from rsmtool.utils import agreement, partial_correlations
+from rsmtool.utils import agreement, partial_correlations, standardized_mean_difference
 
 
 class Analyzer:
@@ -665,14 +665,11 @@ class Analyzer:
         if not population_human_score_sd:
             population_human_score_sd = human_score_sd
 
-        # compute standardized mean difference as recommended
-        # by Williamson et al (2012). Note this metrics is only
-        # applicable when both sets of scores are on the same scale.
-        numerator = mean_system_score - mean_human_score
-        denominator = np.sqrt((population_system_score_sd**2 + population_human_score_sd**2) / 2)
-
-        # if the denominator is zero, then return NaN as the SMD
-        SMD = np.nan if denominator == 0 else numerator / denominator
+        # calculate the standardized mean difference
+        SMD = standardized_mean_difference(mean_system_score,
+                                           mean_human_score,
+                                           population_system_score_sd,
+                                           population_human_score_sd)
 
         # compute r2 and MSE
         r2 = r2_score(human_scores, system_scores)

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -501,6 +501,51 @@ def agreement(score1, score2, tolerance=0):
     return agreement_value
 
 
+def standardized_mean_difference(mean_system_score,
+                                 mean_human_score,
+                                 population_system_score_sd,
+                                 population_human_score_sd):
+    """
+    This function computes the standardized mean
+    difference between a system score and human score
+    for a particular subgroup.
+
+    Parameters
+    ----------
+    mean_system_score : float
+        The mean system score for the group or subgroup.
+    mean_human_score: float
+        The mean human score for the group or subgroup.
+    population_system_score_sd : float
+        The population system score standard deviation.
+        When the SMD is being calculated for a subgroup,
+        this should be the standard deviation for the whole
+        population.
+    population_system_score_sd : float
+        The population human score standard deviation.
+        When the SMD is being calculated for a subgroup,
+        this should be the standard deviation for the whole
+        population.
+
+    Returns
+    -------
+    smd : float
+        The SMD for the given group or subgroup.
+
+    Notes
+    -----
+    This implementation was recommended by Williamson et al (2012).
+    The metric is only applicable when both sets of scores are on
+    the same scale.
+    """
+    numerator = mean_system_score - mean_human_score
+    denominator = np.sqrt((population_system_score_sd**2 + population_human_score_sd**2) / 2)
+
+    # if the denominator is zero, then return NaN as the SMD
+    smd = np.nan if denominator == 0 else numerator / denominator
+    return smd
+
+
 def float_format_func(num, prec=3):
     """
     Format the given floating point number to the specified precision

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -521,7 +521,7 @@ def standardized_mean_difference(mean_system_score,
         When the SMD is being calculated for a subgroup,
         this should be the standard deviation for the whole
         population.
-    population_system_score_sd : float
+    population_human_score_sd : float
         The population human score standard deviation.
         When the SMD is being calculated for a subgroup,
         this should be the standard deviation for the whole

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -548,12 +548,12 @@ def standardized_mean_difference(mean_system_score,
         numerator = mean_system_score - mean_human_score
         denominator = np.sqrt((population_system_score_sd**2 +
                                population_human_score_sd**2) / 2)
-
-        # if the denominator is zero, then return NaN as the SMD
-        smd = np.nan if denominator == 0 else numerator / denominator
     else:
         raise ValueError("Currently, only the 'williamson' SMD method is "
                          "supported. You specified: {}".format(method))
+
+    # if the denominator is zero, then return NaN as the SMD
+    smd = np.nan if denominator == 0 else numerator / denominator
     return smd
 
 

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -504,7 +504,8 @@ def agreement(score1, score2, tolerance=0):
 def standardized_mean_difference(mean_system_score,
                                  mean_human_score,
                                  population_system_score_sd,
-                                 population_human_score_sd):
+                                 population_human_score_sd,
+                                 method='williamson'):
     """
     This function computes the standardized mean
     difference between a system score and human score
@@ -526,6 +527,10 @@ def standardized_mean_difference(mean_system_score,
         When the SMD is being calculated for a subgroup,
         this should be the standard deviation for the whole
         population.
+    method : str, optional
+        The SMD method to use. Currently, only
+        'williamson' is supported.
+        Defaults to 'williamson'.
 
     Returns
     -------
@@ -534,15 +539,21 @@ def standardized_mean_difference(mean_system_score,
 
     Notes
     -----
-    This implementation was recommended by Williamson et al (2012).
-    The metric is only applicable when both sets of scores are on
-    the same scale.
+    The current implementation was recommended by Williamson et al (2012).
+    The metric is only applicable when both sets of scores are on the same
+    scale. Additional implementations may be added in the future.
     """
-    numerator = mean_system_score - mean_human_score
-    denominator = np.sqrt((population_system_score_sd**2 + population_human_score_sd**2) / 2)
+    method = method.lower()
+    if method == 'williamson':
+        numerator = mean_system_score - mean_human_score
+        denominator = np.sqrt((population_system_score_sd**2 +
+                               population_human_score_sd**2) / 2)
 
-    # if the denominator is zero, then return NaN as the SMD
-    smd = np.nan if denominator == 0 else numerator / denominator
+        # if the denominator is zero, then return NaN as the SMD
+        smd = np.nan if denominator == 0 else numerator / denominator
+    else:
+        raise ValueError("Currently, only the 'williamson' SMD method is "
+                         "supported. You specified: {}".format(method))
     return smd
 
 

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -539,7 +539,7 @@ def standardized_mean_difference(mean_system_score,
 
     Notes
     -----
-    The current implementation was recommended by Williamson et al (2012).
+    The current implementation was recommended by Williamson, et al. (2012).
     The metric is only applicable when both sets of scores are on the same
     scale. Additional implementations may be added in the future.
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -270,16 +270,14 @@ def test_get_output_directory_extension_error():
 def test_standardized_mean_difference():
 
     # test SMD
-
-    expected = 1 / 3
-    smd = standardized_mean_difference(9, 8, 3, 3)
-    eq_(round(smd, 3), round(expected, 3))
+    expected = 1 / 4
+    smd = standardized_mean_difference(9, 8, 4, 4)
+    eq_(smd, expected)
 
 
 def test_standardized_mean_difference_zero_denominator():
 
     # test SMD with zero denominator
-
     smd = standardized_mean_difference(4.2, 3.2, 0, 0)
     assert np.isnan(smd)
 
@@ -287,10 +285,17 @@ def test_standardized_mean_difference_zero_denominator():
 def test_standardized_mean_difference_zero_difference():
 
     # test SMD with zero difference between groups
-
     expected = 0.0
     smd = standardized_mean_difference(4.2, 4.2, 1.1, 1.1)
     eq_(smd, expected)
+
+
+@raises(ValueError)
+def test_standardized_mean_difference_fake_method():
+
+    # test SMD with fake method
+    standardized_mean_difference(4.2, 4.2, 1.1, 1.1,
+                                 method='foobar')
 
 
 class TestIntermediateFiles:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,8 @@ from rsmtool.utils import (float_format_func,
                            get_output_directory_extension,
                            get_thumbnail_as_html,
                            get_files_as_html,
-                           compute_expected_scores_from_model)
+                           compute_expected_scores_from_model,
+                           standardized_mean_difference)
 
 from sklearn.datasets import make_classification
 from skll import FeatureSet, Learner
@@ -264,6 +265,32 @@ def test_get_output_directory_extension():
 def test_get_output_directory_extension_error():
     directory = join(test_dir, 'data', 'files')
     get_output_directory_extension(directory, 'id_1')
+
+
+def test_standardized_mean_difference():
+
+    # test SMD
+
+    expected = 1 / 3
+    smd = standardized_mean_difference(9, 8, 3, 3)
+    eq_(round(smd, 3), round(expected, 3))
+
+
+def test_standardized_mean_difference_zero_denominator():
+
+    # test SMD with zero denominator
+
+    smd = standardized_mean_difference(4.2, 3.2, 0, 0)
+    assert np.isnan(smd)
+
+
+def test_standardized_mean_difference_zero_difference():
+
+    # test SMD with zero difference between groups
+
+    expected = 0.0
+    smd = standardized_mean_difference(4.2, 4.2, 1.1, 1.1)
+    eq_(smd, expected)
 
 
 class TestIntermediateFiles:


### PR DESCRIPTION
This PR addresses #217. It creats adds a separate `standardized_mean_difference()` function that can be called outside `rsmtool`.

**Note:** This PR should not be reviewed until after #220 is reviewed.