### PR TITLE
Add methods to `Configuration` and update `copy()` in `Container`

### DIFF
--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -172,7 +172,8 @@ class Configuration:
         Parameters
         ----------
         new_path : str
-            A new file path for the Configuration object.
+            A new file path for the
+            configuration object.
         """
         self._filepath = new_path
 
@@ -182,6 +183,19 @@ class Configuration:
         Get the context.
         """
         return self._context
+
+    @context.setter
+    def context(self, new_context):
+        """
+        Set a new context
+
+        Parameters
+        ----------
+        new_context : str
+            A new context  for the
+            configuration object.
+        """
+        self._context = new_context
 
     def get(self, key, default=None):
         """
@@ -242,19 +256,20 @@ class Configuration:
         Returns
         -------
         items : list of tuples
-            A list of (key, value) tuples in the Configuration object.
+            A list of (key, value) tuples in the
+            configuration object.
         """
         return [(k, v) for k, v in self._config.items()]
 
     def pop(self, key, default=None):
         """
         Remove and returns an element from
-        the object  having the given key.
+        the object having the given key.
 
         Parameters
         ----------
         key : str
-            Key to pop in the Configuration object.
+            Key to pop in the configuration object.
         default, optional
             The default value to return, if no key exists.
             Defaults to None.

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -15,6 +15,7 @@ import logging
 import re
 import warnings
 
+from copy import copy, deepcopy
 from collections import Counter
 from configparser import ConfigParser
 
@@ -244,6 +245,45 @@ class Configuration:
             A list of (key, value) tuples in the Configuration object.
         """
         return [(k, v) for k, v in self._config.items()]
+
+    def pop(self, key, default=None):
+        """
+        Remove and returns an element from
+        the object  having the given key.
+
+        Parameters
+        ----------
+        key : str
+            Key to pop in the Configuration object.
+        default, optional
+            The default value to return, if no key exists.
+            Defaults to None.
+
+        Returns
+        -------
+        value
+            The value removed from the object.
+        """
+        return self._config.pop(key, default)
+
+    def copy(self, deep=True):
+        """
+        Return a copy of the object.
+
+        Parameters
+        ----------
+        deep : bool, optional
+            Whether to perform a deep copy.
+            Defaults to True.
+
+        Returns
+        -------
+        copy : Configuration
+            A new configuration object.
+        """
+        if deep:
+            return deepcopy(self)
+        return copy(self)
 
     def save(self, output_dir=None):
         """

--- a/rsmtool/container.py
+++ b/rsmtool/container.py
@@ -11,6 +11,7 @@ in a pd.DataFrame object.
 """
 
 import warnings
+from copy import copy, deepcopy
 
 
 class DataContainer:
@@ -375,13 +376,6 @@ class DataContainer:
             underlying data frames.
             Defaults to True.
         """
-        dataset_list = []
-        for name in self.keys():
-            frame = self._dataframes[name].copy(deep=deep)
-            path = self._data_paths[name]
-            dataset_dict = {'name': name,
-                            'frame': frame,
-                            'path': path}
-            dataset_list.append(dataset_dict)
-
-        return DataContainer(dataset_list)
+        if deep:
+            return deepcopy(self)
+        return copy(self)

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -485,6 +485,14 @@ class TestConfiguration:
                                context=context)
         eq_(config.context, context)
 
+    def test_set_context(self):
+        context = 'rsmtool'
+        new_context = 'rsmcompare'
+        config = Configuration({"flag_column": "[advisories]"},
+                               context=context)
+        config.context = new_context
+        eq_(config.context, new_context)
+
     def test_get(self):
         config = Configuration({"flag_column": "[advisories]"})
         eq_(config.get('flag_column'), "[advisories]")

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_array_equal
 from pandas.util.testing import assert_frame_equal
 
 from nose.tools import (assert_equal,
+                        assert_not_equal,
                         assert_raises,
                         eq_,
                         ok_,
@@ -364,6 +365,44 @@ class TestConfigurationParser:
 
 
 class TestConfiguration:
+
+    def test_pop_value(self):
+        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        config = Configuration(dictionary)
+        value = config.pop("experiment_id")
+        eq_(value, '001')
+
+    def test_pop_value_default(self):
+        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        config = Configuration(dictionary)
+        value = config.pop("foo", "bar")
+        eq_(value, 'bar')
+
+    def test_copy(self):
+        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6,
+                      "object": [1, 2, 3]}
+        config = Configuration(dictionary)
+        config_copy = config.copy()
+        assert_not_equal(id(config), id(config_copy))
+        for key in config.keys():
+
+            # check to make sure this is a deep copy
+            if key == "object":
+                assert_not_equal(id(config[key]), id(config_copy[key]))
+            assert_equal(config[key], config_copy[key])
+
+    def test_copy_not_deep(self):
+        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6,
+                      "object": [1, 2, 3]}
+        config = Configuration(dictionary)
+        config_copy = config.copy(deep=False)
+        assert_not_equal(id(config), id(config_copy))
+        for key in config.keys():
+
+            # check to make sure this is a shallow copy
+            if key == "object":
+                assert_equal(id(config[key]), id(config_copy[key]))
+            assert_equal(config[key], config_copy[key])
 
     def test_check_flag_column(self):
         input_dict = {"advisory flag": ['0']}

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import warnings
 
-from nose.tools import assert_false, eq_, raises
+from nose.tools import assert_false, assert_equal, assert_not_equal, eq_, raises
 from pandas.util.testing import assert_frame_equal
 from rsmtool.container import DataContainer
 
@@ -25,6 +25,7 @@ class TestBuilderDataContainer:
         container = DataContainer([{'frame': expected, 'name': 'test', 'path': 'foo'}])
         new_container = container.copy()
 
+        assert_not_equal(id(new_container), id(container))
         for name in new_container.keys():
 
             frame = new_container.get_frame(name)
@@ -35,6 +36,33 @@ class TestBuilderDataContainer:
 
             eq_(path, old_path)
             assert_frame_equal(frame, old_frame)
+            assert_not_equal(id(frame), id(old_frame))
+
+    def test_copy_not_deep(self):
+
+        expected = pd.DataFrame([['John', 1, 5.0],
+                                 ['Mary', 2, 4.0],
+                                 ['Sally', 6, np.nan],
+                                 ['Jeff', 3, 9.0],
+                                 ['Edwin', 9, 1.0]],
+                                columns=['string', 'numeric',
+                                         'numeric_missing'])
+
+        container = DataContainer([{'frame': expected, 'name': 'test', 'path': 'foo'}])
+        new_container = container.copy(deep=False)
+
+        assert_not_equal(id(new_container), id(container))
+        for name in new_container.keys():
+
+            frame = new_container.get_frame(name)
+            path = new_container.get_path(name)
+
+            old_frame = container.get_frame(name)
+            old_path = container.get_path(name)
+
+            eq_(path, old_path)
+            assert_frame_equal(frame, old_frame)
+            assert_equal(id(frame), id(old_frame))
 
     def test_rename(self):
 


### PR DESCRIPTION
This is a small PR to address the following:

- Adds `pop()` and `copy()` methods to `Configuration` class (issue #233).
- Adds `context` setter to `Configuration` class.
- Updates `copy()` method in `Container` class to use Python's `copy` library instead.
- Adds tests for all of the above.

None of these updates are required for the operation of `rsmtool`, but could be useful for the API.