### PR TITLE
Typos in documentation

### DIFF
--- a/doc/config_rsmtool.rst
+++ b/doc/config_rsmtool.rst
@@ -129,7 +129,7 @@ flag_column *(Optional)*
 """"""""""""""""""""""""
 This field makes it possible to only use responses with particular values in a given column (e.g. only responses with a value of ``0`` in a column called ``ADVISORY``). The field takes a dictionary in Python format where the keys are the names of the columns and the values are lists of values for responses that will be used to train the model. For example, a value of ``{"ADVISORY": 0}`` will mean that ``rsmtool`` will *only* use responses for which the ``ADVISORY`` column has the value 0. 
 If this field is used without ``flag_column_test``, the conditions will be applied to *both* training and evaluation set and the specified columns must be present in both sets. 
-When this field is used in conjunction with ``_flag_column_test``, the conditions will be applied to *training set only* and the specified columns must be present in the training set.
+When this field is used in conjunction with ``flag_column_test``, the conditions will be applied to *training set only* and the specified columns must be present in the training set.
 Defaults to ``None``.
 
 .. note::

--- a/doc/config_rsmtool.rst
+++ b/doc/config_rsmtool.rst
@@ -128,7 +128,8 @@ The name for an optional column in the test data containing a second human score
 flag_column *(Optional)*
 """"""""""""""""""""""""
 This field makes it possible to only use responses with particular values in a given column (e.g. only responses with a value of ``0`` in a column called ``ADVISORY``). The field takes a dictionary in Python format where the keys are the names of the columns and the values are lists of values for responses that will be used to train the model. For example, a value of ``{"ADVISORY": 0}`` will mean that ``rsmtool`` will *only* use responses for which the ``ADVISORY`` column has the value 0. 
-When this field is used, the specified columns must be present in the training set and, if ``flag_column_tes`` is not passed, the evaluation set, as well. 
+If this field is used without ``flag_column_test``, the conditions will be applied to *both* training and evaluation set and the specified columns must be present in both sets. 
+When this field is used in conjunction with ``_flag_column_test``, the conditions will be applied to *training set only* and the specified columns must be present in the training set.
 Defaults to ``None``.
 
 .. note::
@@ -147,8 +148,13 @@ flag_column_test *(Optional)*
 """""""""""""""""""""""""""""
 This field makes it possible to only use a separate Python flag dictionary for the evaluation set. If this field is not passed, and ``flag_column`` is passed, then the same advisories will be used for both training and evaluation sets. 
 
+
 When this field is used, the specified columns must be present in the evaluation set. 
 Defaults to ``None`` or `flag_column``, if ``flag_column`` is present. Use ``flag_column_test`` only if you want filtering of the test set.
+
+.. note::
+    
+    When used, ``flag_column_test`` field determines *all* filtering conditions for the evaluation set. If it is used in conjunction with ``flag_column`` field, the filtering conditions defined in ``flag_column`` will *only* be applied to the training set. If you want to apply a subset of conditions to both partitions with additional conditions applied to the evaluation set only, you will need to specify the overlapping conditions separately for each partition.   
 
 .. _exclude_zero_scores_rsmtool:
 

--- a/doc/tutorial_rsmpredict.rst
+++ b/doc/tutorial_rsmpredict.rst
@@ -71,7 +71,7 @@ Now that we have the model, the features in the right format, and our configurat
 
 This should produce output like::
 
-    WARNING: The following extraenous features will be ignored: {'spkitemid', 'sc1', 'sc2', 'LENGTH'}
+    WARNING: The following extraneous features will be ignored: {'spkitemid', 'sc1', 'sc2', 'LENGTH'}
     Pre-processing input features
     Generating predictions
     Rescaling predictions

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -290,7 +290,6 @@ class Configuration:
             exclude_listwise = True
         return exclude_listwise
 
-    
     def check_flag_column(self,
                           flag_column='flag_column',
                           partition='unknown'):
@@ -303,11 +302,11 @@ class Configuration:
         Parameters
         ----------
         flag_column : str
-            The flag column to check. Currently used fields are `flag_column` or 
+            The flag column to check. Currently used fields are `flag_column` or
             `flag_column_test`.
             Defaults to 'flag_column'.
 
-        partition: str
+        partition: {'train', 'test', 'both', 'unknown'}
             Partition which is filtered based on the flag column.
             This is used to display more helpful warning messages.
             Defaults to 'both'
@@ -324,7 +323,7 @@ class Configuration:
 
             If `partition` value if not in the expected list
 
-            If `partition` value does not match the `flag_column` 
+            If `partition` value does not match the `flag_column`
         """
         config = self._config
 
@@ -335,17 +334,15 @@ class Configuration:
                         'both': 'training and evaluating',
                         'unknown': 'training and/or evaluating'}
 
-        if not partition in flag_message:
+        if partition not in flag_message:
             raise ValueError("Unknown value for partition: {} "
-                            "This must be one of "
-                            "the following: {}".format(partition,
-                                                       ','.join(flag_message.keys())))
-
+                             "This must be one of the following: {}."
+                             "".format(partition, ','.join(flag_message.keys())))
 
         if flag_column == 'flag_column_test':
             if partition in ['both', 'train']:
                 raise ValueError("The conditions specified in `flag_column_test` "
-                                 "can only be applied to the evaluation partition")
+                                 "can only be applied to the evaluation partition.")
 
         if config.get(flag_column):
 
@@ -353,9 +350,9 @@ class Configuration:
 
             # first check that the value is a dictionary
             if not isinstance(original_filter_dict, dict):
-                raise ValueError("'flag_column' must be a dictionary. "
+                raise ValueError("`flag_column` must be a dictionary. "
                                  "Please refer to the documentation for "
-                                 "further information")
+                                 "further information.")
 
             for column in original_filter_dict:
 

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1509,11 +1509,11 @@ class FeaturePreprocessor:
             omitted_features = set(requested_feature_names).difference(df_filtered.columns)
             if omitted_features:
                 raise ValueError("The following requested features "
-                                "were excluded because their standard "
-                                "deviation on the training set was 0: {}.\n"
-                                "Please edit the feature file to exclude "
-                                "these features and re-run the "
-                                "tool".format(', '.join(omitted_features)))
+                                 "were excluded because their standard "
+                                 "deviation on the training set was 0: {}.\n"
+                                 "Please edit the feature file to exclude "
+                                 "these features and re-run the "
+                                 "tool".format(', '.join(omitted_features)))
             # Update the feature names
             feature_names = [feature for feature in feature_names
                              if feature in df_filtered]
@@ -1718,7 +1718,7 @@ class FeaturePreprocessor:
                             " unexpected behavior.")
 
         # are we filtering on any other columns?
-        # is `flag_column` applied to training partition only 
+        # is `flag_column` applied to training partition only
         # or both partitions?
         if 'flag_column_test' in config_obj:
             flag_partition = 'train'

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1718,8 +1718,16 @@ class FeaturePreprocessor:
                             " unexpected behavior.")
 
         # are we filtering on any other columns?
-        flag_column_dict = config_obj.check_flag_column()
-        flag_column_test_dict = config_obj.check_flag_column('flag_column_test')
+        # is `flag_column` applied to training partition only 
+        # or both partitions?
+        if 'flag_column_test' in config_obj:
+            flag_partition = 'train'
+        else:
+            flag_partition = 'both'
+
+        flag_column_dict = config_obj.check_flag_column(partition=flag_partition)
+        flag_column_test_dict = config_obj.check_flag_column('flag_column_test',
+                                                             partition='test')
 
         if (flag_column_dict and not flag_column_test_dict):
             flag_column_test_dict = flag_column_dict
@@ -2104,7 +2112,7 @@ class FeaturePreprocessor:
                             " unexpected behavior.")
 
         # are we filtering on any other columns?
-        flag_column_dict = config_obj.check_flag_column()
+        flag_column_dict = config_obj.check_flag_column(partition='test')
 
         # do we have the training set predictions and human scores CSV file
         scale_with = config_obj.get('scale_with')
@@ -2386,7 +2394,7 @@ class FeaturePreprocessor:
         predict_expected_scores = config_obj['predict_expected_scores']
 
         # get the column names for flag columns (if any)
-        flag_column_dict = config_obj.check_flag_column()
+        flag_column_dict = config_obj.check_flag_column(partition='test')
 
         # get the name for the candidate_column (if any)
         candidate_column = config_obj['candidate_column']

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -2583,7 +2583,7 @@ class FeaturePreprocessor:
 
         extra_features = set(input_feature_columns).difference(required_features + ['spkitemid'])
         if extra_features:
-            logging.warning('The following extraenous features '
+            logging.warning('The following extraneous features '
                             'will be ignored: {}'.format(extra_features))
 
         # keep the required features plus the id

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -371,6 +371,13 @@ class TestConfiguration:
         output_dict = config.check_flag_column()
         eq_(input_dict, output_dict)
 
+
+    def test_check_flag_column_flag_column_test(self):
+        input_dict = {"advisory flag": ['0']}
+        config = Configuration({"flag_column_test": input_dict})
+        output_dict = config.check_flag_column("flag_column_test")
+        eq_(input_dict, output_dict)
+
     def test_check_flag_column_keep_numeric(self):
         input_dict = {"advisory flag": [1, 2, 3]}
         config = Configuration({"flag_column": input_dict})
@@ -387,10 +394,30 @@ class TestConfiguration:
         flag_dict = config.check_flag_column()
         eq_(flag_dict, {"advisories": ['0']})
 
+
+    def test_check_flag_column_convert_to_list_test(self):
+        config = Configuration({"flag_column": {"advisories": "0"}})
+        flag_dict = config.check_flag_column(partition='test')
+        eq_(flag_dict, {"advisories": ['0']})
+
+
+    def test_check_flag_column_convert_to_list_train(self):
+        config = Configuration({"flag_column": {"advisories": "0"}})
+        flag_dict = config.check_flag_column(partition='train')
+        eq_(flag_dict, {"advisories": ['0']})
+
+
+    def test_check_flag_column_convert_to_list_both(self):
+        config = Configuration({"flag_column": {"advisories": "0"}})
+        flag_dict = config.check_flag_column(partition='both')
+        eq_(flag_dict, {"advisories": ['0']})
+
+
     def test_check_flag_column_convert_to_list_keep_numeric(self):
         config = Configuration({"flag_column": {"advisories": 123}})
         flag_dict = config.check_flag_column()
         eq_(flag_dict, {"advisories": [123]})
+
 
     def test_contains_key(self):
         config = Configuration({"flag_column": {"advisories": 123}})
@@ -421,6 +448,26 @@ class TestConfiguration:
     def test_check_flag_column_wrong_format(self):
         config = Configuration({"flag_column": "[advisories]"})
         config.check_flag_column()
+
+    
+    @raises(ValueError)
+    def test_check_flag_column_wrong_partition(self):
+        config = Configuration({"flag_column_test": {"advisories": 123}})
+        flag_dict = config.check_flag_column(partition='eval')
+
+
+    @raises(ValueError)
+    def test_check_flag_column_mismatched_partition(self):
+        config = Configuration({"flag_column_test": {"advisories": 123}})
+        flag_dict = config.check_flag_column(flag_column='flag_column_test',
+                                             partition='train')
+
+
+    @raises(ValueError)
+    def test_check_flag_column_mismatched_partition_both(self):
+        config = Configuration({"flag_column_test": {"advisories": 123}})
+        flag_dict = config.check_flag_column(flag_column='flag_column_test',
+                                             partition='both')
 
     def test_str_correct(self):
         config_dict = {'flag_column': '[advisories]'}


### PR DESCRIPTION
* Fixed few typos in documentation and messages (#193)
* Based on feedback, added further detail about the use of `flag_column_test` and updated the code to indicate partition when checking the flag column (#211). @jbiggsets please check this does not break any of your code.