### PR TITLE
Fix build versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.6
   - ipython=7.9.0
+  - jupyter_console=6.0.0
   - notebook=6.0.1
   - numpy=1.14.6
   - skll=1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jupyter
+jupyter_console==6.0.0
 nose
 notebook
 numpy==1.14.6


### PR DESCRIPTION
This is a PR to address the failing builds resulting from the following error:

```
ERROR: ipython 7.10.1 has requirement prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0, but you'll have prompt-toolkit 1.0.18 which is incompatible.
``` 

For now, we just pin `jupyter_console` to version `6.0.0`. However, we'll want to remove `jupyter_console` from the requirements list once this incompatibility is resolved. See issue #323 for more details.