### PR TITLE
Suppress convergence warnings for LinearSVR test (Also make future warning suppression easier)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,10 @@ channels:
   - ets
 dependencies:
   - python=3.6
-  - ipython=7.9.0
-  - jupyter_console=6.0.0
-  - notebook=6.0.1
+  - ipython
+  - notebook
   - numpy=1.14.6
+  - pandas==0.23.4
+  - seaborn
   - skll=2.0.0
-  - statsmodels=0.10.1
+  - statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jupyter
-jupyter_console==6.0.0
 nose
 notebook
 numpy==1.14.6

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -40,7 +40,8 @@ def check_run_experiment(source,
                          consistency=False,
                          skll=False,
                          file_format='csv',
-                         given_test_dir=None):
+                         given_test_dir=None,
+                         suppress_warnings_for=[]):
     """
     Function to run for a parameterized rsmtool experiment test.
 
@@ -71,6 +72,9 @@ def check_run_experiment(source,
         Path where the test experiments are located. Unless specified, the
         rsmtool test directory is used. This can be useful when using these
         experiments to run tests for RSMExtra.
+    suppress_warnings_for : list, optional
+        Categories for which warnings should be suppressed when running the
+        experiments.
     """
     # use the test directory from this file unless it's been overridden
     test_dir = given_test_dir if given_test_dir else rsmtool_test_dir
@@ -83,9 +87,10 @@ def check_run_experiment(source,
 
     model_type = 'skll' if skll else 'rsmtool'
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=RuntimeWarning)
-        do_run_experiment(source, experiment_id, config_file)
+    do_run_experiment(source,
+                      experiment_id,
+                      config_file,
+                      suppress_warnings_for=suppress_warnings_for)
 
     output_dir = join('test_outputs', source, 'output')
     expected_output_dir = join(test_dir, 'data', 'experiments', source, 'output')
@@ -304,7 +309,10 @@ def check_run_summary(source, file_format='csv', given_test_dir=None):
     check_report(html_report)
 
 
-def do_run_experiment(source, experiment_id, config_file):
+def do_run_experiment(source,
+                      experiment_id,
+                      config_file,
+                      suppress_warnings_for=[]):
     """
     Run RSMTool experiment using the given experiment
     configuration file located in the given source directory
@@ -318,6 +326,10 @@ def do_run_experiment(source, experiment_id, config_file):
         Experiment ID to use when running.
     config_file : str
         Path to the experiment configuration file.
+    suppress_warnings_for : list, optional
+        Categories for which warnings should be suppressed
+        when running the experiments. Note that ``RuntimeWarning``s
+        are always suppressed.
     """
     source_output_dir = 'test_outputs'
     experiment_dir = join(source_output_dir, source)
@@ -327,7 +339,17 @@ def do_run_experiment(source, experiment_id, config_file):
         files = glob(join(source_output_dir, source, output_subdir, '*'))
         for f in files:
             remove(f)
-    run_experiment(config_file, experiment_dir)
+
+    with warnings.catch_warnings():
+
+        # always suppress runtime warnings
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+
+        # suppress additional warning types if specified
+        for warning_type in suppress_warnings_for:
+            warnings.filterwarnings('ignore', category=warning_type)
+
+        run_experiment(config_file, experiment_dir)
 
 
 def do_run_evaluation(source, experiment_id, config_file):

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -160,9 +160,10 @@ def test_run_experiment_lr_old_config():
                        '{}.json'.format(experiment_id))
 
     # run this experiment but suppress the expected deprecation warnings
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        do_run_experiment(source, experiment_id, config_file)
+    do_run_experiment(source,
+                      experiment_id,
+                      config_file,
+                      suppress_warnings_for=[DeprecationWarning])
 
 
 @raises(ValueError)
@@ -179,9 +180,10 @@ def test_run_experiment_lr_feature_json():
                        '{}.json'.format(experiment_id))
 
     # run this experiment but suppress the expected deprecation warnings
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        do_run_experiment(source, experiment_id, config_file)
+    do_run_experiment(source,
+                      experiment_id,
+                      config_file,
+                      suppress_warnings_for=[DeprecationWarning])
 
 
 @raises(FileNotFoundError)

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 from glob import glob
 from os.path import basename, exists, join

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -4,6 +4,7 @@ from os.path import join
 
 from nose.tools import raises, assert_equal
 from parameterized import param, parameterized
+from sklearn.exceptions import ConvergenceWarning
 
 from rsmtool.test_utils import (check_run_experiment,
                                 collect_warning_messages_from_report,

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -51,10 +51,16 @@ else:
 def test_run_experiment_parameterized(*args, **kwargs):
     if TEST_DIR:
         kwargs['given_test_dir'] = TEST_DIR
+
+    # suppress known convergence warnings for LinearSVR-based experiments
+    # TODO: once SKLL hyperparameters can be passed, replace this code
+    if args[0].startswith('linearsvr'):
+        kwargs['suppress_warnings_for'] = [ConvergenceWarning]
+
     check_run_experiment(*args, **kwargs)
 
 
-@raises(ValueError)
+# @raises(ValueError)
 def test_run_experiment_empwtdropneg():
 
     # rsmtool experiment with no longer supported empWtDropNeg model

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -61,7 +61,7 @@ def test_run_experiment_parameterized(*args, **kwargs):
     check_run_experiment(*args, **kwargs)
 
 
-# @raises(ValueError)
+@raises(ValueError)
 def test_run_experiment_empwtdropneg():
 
     # rsmtool experiment with no longer supported empWtDropNeg model


### PR DESCRIPTION
As discussed in #351, the current solution is to simply suppress the convergence warnings coming from scikit-learn until we can pass in custom values for SKLL hyperparameters.

In addition, I also made it much simpler to add future suppression warnings for tests based on `run_experiment`. I modified `check_run_experiment()` and `do_run_experiment()`  to accept a list of warning types as a keyword argument. This will allow any types of warnings to be suppressed and doesn't require adding individual `filterwarnings()` in each test.