### PR TITLE
Clean up and align `requirements.txt` and `environment.yml` 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,10 @@ channels:
   - ets
 dependencies:
   - python=3.6
-  - ipython=7.9.0
-  - jupyter_console=6.0.0
-  - notebook=6.0.1
+  - ipython
+  - notebook
   - numpy=1.14.6
+  - pandas==0.23.4
+  - seaborn
   - skll=2.0.0
-  - statsmodels=0.10.1
+  - statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jupyter
-jupyter_console==6.0.0
 nose
 notebook
 numpy==1.14.6


### PR DESCRIPTION
- `jupyter_console` gets installed automatically so no need to explicitly pin it to get around some weird conda packaging issue (see #323).
- No need to pin `ipython``, notebook`, and `statsmodels` since they are relatively stable and not likely to change their interfaces.
- Pin `pandas` in `environment.yml` just like we do in `requirements.txt`.
- Add `seaborn` to `environment.yml`