### PR TITLE
352 capture expected warnings in tests

### DIFF
--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -122,8 +122,8 @@ class Configuration:
         configdir : str, optional, keyword-only
             The reference path used to
             resolve any relative paths in the configuration
-            object. When None, will be set to
-            current working directory.
+            object. When None, will be set during
+            initialization to the current working directory.
             Defaults to None
         filename : str, optional, keyword-only
             The name of the configuration file.
@@ -145,10 +145,10 @@ class Configuration:
         # set configdir to `cwd` if not given and let the user know
         if configdir is None:
             configdir = getcwd()
+            logging.info("Configuration directory will be set to {}".format(configdir))
         else:
             configdir = abspath(configdir)
-            logging.info("Configuration directory will be set to {}".format(configdir))
-
+        
         self._configdir = configdir
         self._filename = filename
 

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -482,8 +482,8 @@ def partial_correlations(df):
             icvx = np.linalg.inv(df_cov)
         except AssertionError:
             icvx = np.linalg.pinv(df_cov)
-            warnings.warn('The inverse of the variance-covariance matrix '
-                          'when computing partial correlations '
+            warnings.warn('When computing partial correlations '
+                          'the inverse of the variance-covariance matrix '
                           'was calculated using the Moore-Penrose generalized '
                           'matrix inversion, due to its determinant being at '
                           'or very close to zero.')

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -483,6 +483,7 @@ def partial_correlations(df):
         except AssertionError:
             icvx = np.linalg.pinv(df_cov)
             warnings.warn('The inverse of the variance-covariance matrix '
+                          'when computing partial correlations '
                           'was calculated using the Moore-Penrose generalized '
                           'matrix inversion, due to its determinant being at '
                           'or very close to zero.')

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -123,7 +123,6 @@ class TestAnalyzer:
             retval = Analyzer.correlation_helper(self.df_features_same_score, 'sc1', 'group')
             assert_equal(retval[0].isnull().values.sum(), 3)
             assert_equal(retval[1].isnull().values.sum(), 3)
-            print([w2.message for w2 in w])
             assert issubclass(w[-1].category, UserWarning)
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -75,11 +75,11 @@ class TestAnalyzer:
         # this should compute marginal correlations and return a unity
         # matrix for partial correlations
         # it should also raise a UserWarning
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warning_list:
             retval = Analyzer.correlation_helper(self.df_features[:4], 'sc1', 'group')
         assert_equal(retval[0].isnull().values.sum(), 0)
         assert_almost_equal(np.abs(retval[1].values).sum(), 0.9244288637889855)
-        assert issubclass(w[-1].category, UserWarning)
+        assert issubclass(warning_list[-1].category, UserWarning)
 
 
 
@@ -118,12 +118,12 @@ class TestAnalyzer:
         # this test should raise UserWarning because the determinant is very close to
         # zero. It also raises Runtime warning because
         # variance of human scores is 0.
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warning_list:
             warnings.filterwarnings('ignore', category=RuntimeWarning)
             retval = Analyzer.correlation_helper(self.df_features_same_score, 'sc1', 'group')
             assert_equal(retval[0].isnull().values.sum(), 3)
             assert_equal(retval[1].isnull().values.sum(), 3)
-            assert issubclass(w[-1].category, UserWarning)
+            assert issubclass(warning_list[-1].category, UserWarning)
 
 
     def test_that_metrics_helper_works_for_data_with_one_row(self):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -74,9 +74,13 @@ class TestAnalyzer:
     def test_correlation_helper_for_data_with_four_rows(self):
         # this should compute marginal correlations and return a unity
         # matrix for partial correlations
-        retval = Analyzer.correlation_helper(self.df_features[:4], 'sc1', 'group')
+        # it should also raise a UserWarning
+        with warnings.catch_warnings(record=True) as w:
+            retval = Analyzer.correlation_helper(self.df_features[:4], 'sc1', 'group')
         assert_equal(retval[0].isnull().values.sum(), 0)
         assert_almost_equal(np.abs(retval[1].values).sum(), 0.9244288637889855)
+        assert issubclass(w[-1].category, UserWarning)
+
 
 
     def test_correlation_helper_for_data_with_groups(self):
@@ -110,12 +114,17 @@ class TestAnalyzer:
 
 
 
-    def test_that_correlation_helper_works_for_data_with_the_same_label(self):
-        with warnings.catch_warnings():
+    def test_that_correlation_helper_works_for_data_with_the_same_human_score(self):
+        # this test should raise UserWarning because the determinant is very close to
+        # zero
+        with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('ignore', category=RuntimeWarning)
             retval = Analyzer.correlation_helper(self.df_features_same_score, 'sc1', 'group')
             assert_equal(retval[0].isnull().values.sum(), 3)
             assert_equal(retval[1].isnull().values.sum(), 3)
+            print([w2.message for w2 in w])
+            assert issubclass(w[-1].category, UserWarning)
+
 
     def test_that_metrics_helper_works_for_data_with_one_row(self):
         # There should be NaNs for SMD, correlations and both sds

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -116,8 +116,8 @@ class TestAnalyzer:
 
     def test_that_correlation_helper_works_for_data_with_the_same_human_score(self):
         # this test should raise UserWarning because the determinant is very close to
-        # zero. It also raises Runtime warning because 
-        # variance of human scores is 0. 
+        # zero. It also raises Runtime warning because
+        # variance of human scores is 0.
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('ignore', category=RuntimeWarning)
             retval = Analyzer.correlation_helper(self.df_features_same_score, 'sc1', 'group')

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -116,7 +116,8 @@ class TestAnalyzer:
 
     def test_that_correlation_helper_works_for_data_with_the_same_human_score(self):
         # this test should raise UserWarning because the determinant is very close to
-        # zero
+        # zero. It also raises Runtime warning because 
+        # variance of human scores is 0. 
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('ignore', category=RuntimeWarning)
             retval = Analyzer.correlation_helper(self.df_features_same_score, 'sc1', 'group')

--- a/tests/test_experiment_rsmtool_1.py
+++ b/tests/test_experiment_rsmtool_1.py
@@ -28,7 +28,10 @@ else:
     param('lr-subgroups', 'lr_subgroups', subgroups=['L1']),
     param('lr-with-numeric-subgroup', 'lr_with_numeric_subgroup', subgroups=['ITEM', 'QUESTION']),
     param('lr-with-id-with-leading-zeros', 'lr_with_id_with_leading_zeros', subgroups=['ITEM', 'QUESTION']),
-    param('lr-subgroups-with-edge-cases', 'lr_subgroups_with_edge_cases', subgroups=['group_edge_cases']),
+    # we suppress UserWarnings for this test since we get a warning in partial correlations 
+    # due to edge cases
+    param('lr-subgroups-with-edge-cases', 'lr_subgroups_with_edge_cases',
+          subgroups=['group_edge_cases'], suppress_warnings_for=[UserWarning]),
     param('lr-missing-values', 'lr_missing_values'),
     param('lr-include-zeros', 'lr_include_zeros'),
     param('lr-with-length', 'lr_with_length'),

--- a/tests/test_experiment_rsmtool_1.py
+++ b/tests/test_experiment_rsmtool_1.py
@@ -28,7 +28,7 @@ else:
     param('lr-subgroups', 'lr_subgroups', subgroups=['L1']),
     param('lr-with-numeric-subgroup', 'lr_with_numeric_subgroup', subgroups=['ITEM', 'QUESTION']),
     param('lr-with-id-with-leading-zeros', 'lr_with_id_with_leading_zeros', subgroups=['ITEM', 'QUESTION']),
-    # we suppress UserWarnings for this test since we get a warning in partial correlations 
+    # we suppress UserWarnings for this test since we expect to get a warning in partial correlations
     # due to edge cases
     param('lr-subgroups-with-edge-cases', 'lr_subgroups_with_edge_cases',
           subgroups=['group_edge_cases'], suppress_warnings_for=[UserWarning]),

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -23,7 +23,7 @@ class TestCopyData():
                          'features': 'temp_test_copy_data_file/features.csv'}
         self.dirs_to_remove.append('temp_test_copy_data_file')
         output_dict = copy_data_files('temp_test_copy_data_file',
-                                           file_dict)
+                                      file_dict)
         for f in expected_dict:
             eq_(output_dict[f], expected_dict[f])
             ok_(Path(output_dict[f]).exists())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -464,7 +464,8 @@ def test_partial_correlations_with_singular_matrix():
 
 def test_partial_correlations_pinv():
 
-    msg = ('The inverse of the variance-covariance matrix was calculated '
+    msg = ('The inverse of the variance-covariance matrix when computing '
+           'partial correlations was calculated '
            'using the Moore-Penrose generalized matrix inversion, due to '
            'its determinant being at or very close to zero.')
     df_small_det = pd.DataFrame({'X1': [1.3, 1.2, 1.5, 1.7, 1.8, 1.9, 2.0],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -284,7 +284,7 @@ def test_standardized_mean_difference():
     eq_(smd, expected)
 
 
-def test_standardized_mean_difference_zero_denominator_jonson():
+def test_standardized_mean_difference_zero_denominator_johnson():
 
     # test SMD with zero denominator
     # we pass 0 as standard deviation of population
@@ -464,8 +464,9 @@ def test_partial_correlations_with_singular_matrix():
 
 def test_partial_correlations_pinv():
 
-    msg = ('The inverse of the variance-covariance matrix when computing '
-           'partial correlations was calculated '
+    msg = ('When computing partial correlations '
+           'the inverse of the variance-covariance matrix '
+           'was calculated '
            'using the Moore-Penrose generalized matrix inversion, due to '
            'its determinant being at or very close to zero.')
     df_small_det = pd.DataFrame({'X1': [1.3, 1.2, 1.5, 1.7, 1.8, 1.9, 2.0],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -410,12 +410,12 @@ def test_difference_of_standardized_means_with_no_population_info():
     expected = -1.7446361815538174e-16
     y_true, y_pred = (np.array([98, 18, 47, 64, 32, 11, 100]),
                       np.array([94, 42, 54, 12, 92, 10, 77]))
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warning_list:
         diff_std_means = difference_of_standardized_means(y_true, y_pred)
     eq_(diff_std_means, expected)
     eq_(len(w), 2)
-    assert issubclass(w[0].category, UserWarning)
-    assert issubclass(w[1].category, UserWarning)
+    assert issubclass(warning_list[0].category, UserWarning)
+    assert issubclass(warning_list[1].category, UserWarning)
 
 
 def test_quadratic_weighted_kappa():
@@ -456,10 +456,10 @@ def test_partial_correlations_with_singular_matrix():
     # of singularity
     expected = pd.DataFrame({0: [1.0, -1.0], 1: [-1.0, 1.0]})
     df_singular = pd.DataFrame(np.tile(np.random.randn(100), (2, 1))).T
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warning_list:
         assert_frame_equal(partial_correlations(df_singular), expected)
-    eq_(len(w), 1)
-    assert issubclass(w[-1].category, UserWarning)
+    eq_(len(warning_list), 1)
+    assert issubclass(warning_list[-1].category, UserWarning)
 
 
 def test_partial_correlations_pinv():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -413,7 +413,7 @@ def test_difference_of_standardized_means_with_no_population_info():
     with warnings.catch_warnings(record=True) as warning_list:
         diff_std_means = difference_of_standardized_means(y_true, y_pred)
     eq_(diff_std_means, expected)
-    eq_(len(w), 2)
+    eq_(len(warning_list), 2)
     assert issubclass(warning_list[0].category, UserWarning)
     assert issubclass(warning_list[1].category, UserWarning)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -657,9 +657,9 @@ class TestExpectedScores():
         cls.test_fs = FeatureSet('test', ids=test_ids, features=test_features)
 
         # train some test SKLL learners that we will use in our tests
-        
+
         # we catch convergence warnings since the model doesn't converge
-        with warnings.catch_warnings() as w:
+        with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=ConvergenceWarning)
             cls.linearsvc = Learner('LinearSVC')
             _ = cls.linearsvc.train(cls.train_fs, grid_search=False)


### PR DESCRIPTION
* This PR partially addresses #352 : I added comments to tests that are expected to raise warnings and warning capture/test to make sure these are handled correctly. 

* We are now catching all `warnings` but none of the logger warnings. See #367 for further discussion:  we need to decide on how to treat these before we make further changes to tests.