### PR TITLE
Make tests run with package and add missing test file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,3 @@ omit =
     */site-packages/nose/*
     */unittest2/*
     *rsmtool/notebooks/templates/report.tpl
-    *rsmtool/test_utils.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
   - TESTFILES="tests/test_experiment_rsmtool_1.py"
   - TESTFILES="tests/test_comparer.py tests/test_configuration_parser.py tests/test_experiment_rsmtool_2.py"
-  - TESTFILES="tests/test_analyzer.py tests/test_experiment_rsmeval.py tests/test_fairness_utils.py tests/test_prmse_utils.py tests/test_container.py test_test_utils.py"
+  - TESTFILES="tests/test_analyzer.py tests/test_experiment_rsmeval.py tests/test_fairness_utils.py tests/test_prmse_utils.py tests/test_container.py tests/test_test_utils.py"
   - TESTFILES="tests/test_experiment_rsmcompare.py tests/test_experiment_rsmsummarize.py tests/test_modeler.py tests/test_preprocessor.py tests/test_writer.py tests/test_experiment_rsmtool_3.py"
   - TESTFILES="tests/test_experiment_rsmpredict.py tests/test_reader.py tests/test_reporter.py tests/test_transformer.py tests/test_utils.py tests/test_experiment_rsmtool_4.py"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
   - TESTFILES="tests/test_experiment_rsmtool_1.py"
   - TESTFILES="tests/test_comparer.py tests/test_configuration_parser.py tests/test_experiment_rsmtool_2.py"
-  - TESTFILES="tests/test_analyzer.py tests/test_experiment_rsmeval.py tests/test_fairness_utils.py tests/test_prmse_utils.py tests/test_container.py"
+  - TESTFILES="tests/test_analyzer.py tests/test_experiment_rsmeval.py tests/test_fairness_utils.py tests/test_prmse_utils.py tests/test_container.py test_test_utils.py"
   - TESTFILES="tests/test_experiment_rsmcompare.py tests/test_experiment_rsmsummarize.py tests/test_modeler.py tests/test_preprocessor.py tests/test_writer.py tests/test_experiment_rsmtool_3.py"
   - TESTFILES="tests/test_experiment_rsmpredict.py tests/test_reader.py tests/test_reporter.py tests/test_transformer.py tests/test_utils.py tests/test_experiment_rsmtool_4.py"
 sudo: false

--- a/DistributeTests.ps1
+++ b/DistributeTests.ps1
@@ -42,6 +42,7 @@ elseif ($agentNumber -eq 3) {
     $testsToRun = $testsToRun + "tests/test_experiment_rsmeval.py"
     $testsToRun = $testsToRun + "tests/test_fairness_utils.py"
     $testsToRun = $testsToRun + "tests/test_prmse_utils.py"
+    $testsToRun = $testsToRun + "tests/test_test_utils.py"
 }
 elseif ($agentNumber -eq 4) {
     $testsToRun = $testsToRun + "tests/test_experiment_rsmcompare.py"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@
 
 variables:
   MPLBACKEND: Agg
+  PYTHON_VERSION: "3.6"
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,6 @@
 
 variables:
   MPLBACKEND: Agg
-  PYTHON_VERSION: "3.6"
 
 trigger:
   branches:

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -929,9 +929,9 @@ def check_subgroup_outputs(output_dir, experiment_id, subgroups, file_format='cs
 
 def copy_data_files(temp_dir_name,
                     input_file_dict,
-                    given_test_dir=None):
+                    given_test_dir):
     """
-    A utility function to copy files from the ``tests/data`` directory into
+    A utility function to copy files from the given test directory into
     a specified temporary directory. Useful for tests where the
     current directory is to be used as the reference for resolving paths
     in the configuration.
@@ -944,9 +944,8 @@ def copy_data_files(temp_dir_name,
         A dictionary of files/directories to copy with keys as the
         file type and the values are their paths relative to the `tests`
         directory.
-    given_test_dir : str, optional
-        Directory where the the test experiments are located. Unless
-        specified, the rsmtool test directory is used. This can be
+    given_test_dir : str
+        Directory where the the test experiments are located. This can be
         useful when using these experiments to run tests for RSMExtra.
 
     Returns
@@ -956,9 +955,6 @@ def copy_data_files(temp_dir_name,
         input_file_dict and values showing new paths.
     """
 
-    # use the test directory from this file unless it's been overridden
-    test_dir = given_test_dir if given_test_dir else rsmtool_test_dir
-
     temp_dir = Path(temp_dir_name)
     if not temp_dir.exists():
         temp_dir.mkdir()
@@ -967,7 +963,7 @@ def copy_data_files(temp_dir_name,
     for file in input_file_dict:
         filepath = Path(input_file_dict[file])
         filename = filepath.name
-        old_filepath = test_dir / filepath
+        old_filepath = given_test_dir / filepath
         new_filepath = temp_dir / filename
         if old_filepath.is_dir():
             copytree(old_filepath, new_filepath)

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -945,9 +945,9 @@ def copy_data_files(temp_dir_name,
         file type and the values are their paths relative to the `tests`
         directory.
     given_test_dir : str, optional
-        Directory where the the test experiments are located. Unless specified, the
-        rsmtool test directory is used. This can be useful when using these
-        experiments to run tests for RSMExtra.
+        Directory where the the test experiments are located. Unless
+        specified, the rsmtool test directory is used. This can be
+        useful when using these experiments to run tests for RSMExtra.
 
     Returns
     -------

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -582,7 +582,7 @@ class TestConfiguration:
             config_dict = {'exp_id': 'my_experiment'}
             config = Configuration(config_dict, filepath)
             eq_(config._filename, 'file.json')
-            eq_(config._configdir, abspath('some/path/'))
+            eq_(config._configdir, abspath('some/path'))
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
 

--- a/tests/test_experiment_rsmcompare.py
+++ b/tests/test_experiment_rsmcompare.py
@@ -100,7 +100,8 @@ def test_run_experiment_lr_compare_with_dictionary():
     old_file_dict = {'experiment_dir': 'data/experiments/lr-self-compare-dict/lr-subgroups'}
 
     new_file_dict = copy_data_files(temp_dir.name,
-                                    old_file_dict)
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"comparison_id": "lr_self_compare_dict",
                    "experiment_dir_old": new_file_dict['experiment_dir'],

--- a/tests/test_experiment_rsmcompare.py
+++ b/tests/test_experiment_rsmcompare.py
@@ -101,7 +101,7 @@ def test_run_experiment_lr_compare_with_dictionary():
 
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"comparison_id": "lr_self_compare_dict",
                    "experiment_dir_old": new_file_dict['experiment_dir'],
@@ -115,11 +115,9 @@ def test_run_experiment_lr_compare_with_dictionary():
                    "subgroups": ["QUESTION"]
                    }
 
-
     check_run_comparison(source,
                          experiment_id,
                          config_obj_or_dict=config_dict)
-
 
 
 @raises(ValueError)

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -135,7 +135,7 @@ def test_run_experiment_lr_eval_with_dictionary():
 
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"predictions_file": new_file_dict['pred'],
                    "system_score_column": "score",

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -133,7 +133,9 @@ def test_run_experiment_lr_eval_with_dictionary():
 
     old_file_dict = {'pred': 'data/files/predictions_scaled_with_subgroups.csv'}
 
-    new_file_dict = copy_data_files(temp_dir.name, old_file_dict)
+    new_file_dict = copy_data_files(temp_dir.name,
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"predictions_file": new_file_dict['pred'],
                    "system_score_column": "score",

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -147,7 +147,7 @@ def test_run_experiment_lr_predict_with_dictionary():
 
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"id_column": "ID",
                    "input_features_file": new_file_dict['feature_file'],

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -146,13 +146,13 @@ def test_run_experiment_lr_predict_with_dictionary():
                      'experiment_dir': 'data/experiments/lr-predict-dict/existing_experiment'}
 
     new_file_dict = copy_data_files(temp_dir.name,
-                                    old_file_dict)
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"id_column": "ID",
                    "input_features_file": new_file_dict['feature_file'],
                    "experiment_dir": new_file_dict['experiment_dir'],
                    "experiment_id": "lr"}
-
 
     check_run_prediction(source,
                          config_obj_or_dict=config_dict)

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -121,13 +121,13 @@ def test_run_experiment_lr_predict_with_object():
                    "experiment_id": "lr"
                    }
 
-
     config_parser = ConfigurationParser()
     config_parser.load_config_from_dict(config_dict,
                                         configdir=configdir)
     config_obj = config_parser.normalize_validate_and_process_config(context='rsmpredict')
 
     check_run_prediction(source,
+                         given_test_dir=rsmtool_test_dir,
                          config_obj_or_dict=config_obj)
 
 
@@ -155,6 +155,7 @@ def test_run_experiment_lr_predict_with_dictionary():
                    "experiment_id": "lr"}
 
     check_run_prediction(source,
+                         given_test_dir=rsmtool_test_dir,
                          config_obj_or_dict=config_dict)
 
 

--- a/tests/test_experiment_rsmsummarize.py
+++ b/tests/test_experiment_rsmsummarize.py
@@ -85,7 +85,9 @@ def test_run_experiment_lr_summary_dictionary():
 
     old_file_dict = {'experiment_dir': 'data/experiments/lr-self-summary-dict/lr-subgroups'}
 
-    new_file_dict = copy_data_files(temp_dir.name, old_file_dict)
+    new_file_dict = copy_data_files(temp_dir.name,
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"summary_id": "model_comparison",
                    "experiment_dirs": [new_file_dict['experiment_dir'],
@@ -94,7 +96,6 @@ def test_run_experiment_lr_summary_dictionary():
                    "description": "Comparison of rsmtool experiment with itself."}
 
     check_run_summary(source, config_obj_or_dict=config_dict)
-
 
 
 def test_run_experiment_lr_summary_no_trim():

--- a/tests/test_experiment_rsmsummarize.py
+++ b/tests/test_experiment_rsmsummarize.py
@@ -87,7 +87,7 @@ def test_run_experiment_lr_summary_dictionary():
 
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"summary_id": "model_comparison",
                    "experiment_dirs": [new_file_dict['experiment_dir'],

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -28,6 +28,7 @@ if TEST_DIR:
 else:
     from rsmtool.test_utils import rsmtool_test_dir
 
+
 @parameterized([
     param('lr-no-standardization', 'lr_no_standardization'),
     param('lr-exclude-test-flags', 'lr_exclude_test_flags'),
@@ -140,7 +141,7 @@ def test_run_experiment_lr_with_object_no_configdir():
     temp_dir = tempfile.TemporaryDirectory(prefix=getcwd())
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"train_file": new_file_dict['train'],
                    "id_column": "ID",
@@ -176,7 +177,7 @@ def test_run_experiment_lr_with_dictionary():
     temp_dir = tempfile.TemporaryDirectory(prefix=getcwd())
     new_file_dict = copy_data_files(temp_dir.name,
                                     old_file_dict,
-                                    given_test_dir=TEST_DIR)
+                                    rsmtool_test_dir)
 
     config_dict = {"train_file": new_file_dict['train'],
                    "id_column": "ID",

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -137,10 +137,10 @@ def test_run_experiment_lr_with_object_no_configdir():
                      'test': 'data/files/test.csv',
                      'features': 'data/experiments/lr-object-no-path/features.csv'}
 
-
     temp_dir = tempfile.TemporaryDirectory(prefix=getcwd())
     new_file_dict = copy_data_files(temp_dir.name,
-                                    old_file_dict)
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"train_file": new_file_dict['train'],
                    "id_column": "ID",
@@ -175,7 +175,8 @@ def test_run_experiment_lr_with_dictionary():
 
     temp_dir = tempfile.TemporaryDirectory(prefix=getcwd())
     new_file_dict = copy_data_files(temp_dir.name,
-                                    old_file_dict)
+                                    old_file_dict,
+                                    given_test_dir=TEST_DIR)
 
     config_dict = {"train_file": new_file_dict['train'],
                    "id_column": "ID",

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+from os.path import join
 from pathlib import Path
 
 from nose.tools import ok_, eq_
@@ -28,8 +29,8 @@ class TestCopyData():
     def test_copy_data_files(self):
         file_dict = {'train': 'data/files/train.csv',
                      'features': 'data/experiments/lr/features.csv'}
-        expected_dict = {'train': os.path.sep.join(['temp_test_copy_data_file', 'train.csv']),
-                         'features': os.path.sep.join(['temp_test_copy_data_file', 'features.csv'])}
+        expected_dict = {'train': join('temp_test_copy_data_file', 'train.csv'),
+                         'features': join('temp_test_copy_data_file', 'features.csv')}
         self.dirs_to_remove.append('temp_test_copy_data_file')
         output_dict = copy_data_files('temp_test_copy_data_file',
                                       file_dict,
@@ -41,7 +42,7 @@ class TestCopyData():
 
     def test_copy_data_files_directory(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups'}
-        expected_dict = {'exp_dir': os.path.sep.join(['temp_test_copy_dirs', 'lr-subgroups'])}
+        expected_dict = {'exp_dir': join('temp_test_copy_dirs', 'lr-subgroups')}
         self.dirs_to_remove.append('temp_test_copy_dirs')
         output_dict = copy_data_files('temp_test_copy_dirs',
                                       file_dict,
@@ -54,8 +55,8 @@ class TestCopyData():
     def test_copy_data_files_files_and_directories(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups',
                      'test': 'data/files/test.csv'}
-        expected_dict = {'exp_dir': os.path.sep.join(['temp_test_copy_mixed', 'lr-subgroups']),
-                         'test': os.path.sep.join(['temp_test_copy_mixed', 'test.csv'])}
+        expected_dict = {'exp_dir': join('temp_test_copy_mixed', 'lr-subgroups'),
+                         'test': join('temp_test_copy_mixed', 'test.csv')}
         self.dirs_to_remove.append('temp_test_copy_mixed')
         output_dict = copy_data_files('temp_test_copy_mixed',
                                       file_dict,

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -28,8 +28,8 @@ class TestCopyData():
     def test_copy_data_files(self):
         file_dict = {'train': 'data/files/train.csv',
                      'features': 'data/experiments/lr/features.csv'}
-        expected_dict = {'train': 'temp_test_copy_data_file/train.csv',
-                         'features': 'temp_test_copy_data_file/features.csv'}
+        expected_dict = {'train': os.path.sep.join(['temp_test_copy_data_file', 'train.csv']),
+                         'features': os.path.sep.join(['temp_test_copy_data_file', 'features.csv'])}
         self.dirs_to_remove.append('temp_test_copy_data_file')
         output_dict = copy_data_files('temp_test_copy_data_file',
                                       file_dict,
@@ -41,7 +41,7 @@ class TestCopyData():
 
     def test_copy_data_files_directory(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups'}
-        expected_dict = {'exp_dir': 'temp_test_copy_dirs/lr-subgroups'}
+        expected_dict = {'exp_dir': os.path.sep.join(['temp_test_copy_dirs', 'lr-subgroups'])}
         self.dirs_to_remove.append('temp_test_copy_dirs')
         output_dict = copy_data_files('temp_test_copy_dirs',
                                       file_dict,
@@ -54,8 +54,8 @@ class TestCopyData():
     def test_copy_data_files_files_and_directories(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups',
                      'test': 'data/files/test.csv'}
-        expected_dict = {'exp_dir': 'temp_test_copy_mixed/lr-subgroups',
-                         'test': 'temp_test_copy_mixed/test.csv'}
+        expected_dict = {'exp_dir': os.path.sep.join(['temp_test_copy_mixed', 'lr-subgroups']),
+                         'test': os.path.sep.join(['temp_test_copy_mixed', 'test.csv'])}
         self.dirs_to_remove.append('temp_test_copy_mixed')
         output_dict = copy_data_files('temp_test_copy_mixed',
                                       file_dict,

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 from pathlib import Path
@@ -5,6 +6,14 @@ from pathlib import Path
 from nose.tools import ok_, eq_
 
 from rsmtool.test_utils import copy_data_files
+
+# allow test directory to be set via an environment variable
+# which is needed for package testing
+TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 class TestCopyData():
@@ -23,24 +32,24 @@ class TestCopyData():
                          'features': 'temp_test_copy_data_file/features.csv'}
         self.dirs_to_remove.append('temp_test_copy_data_file')
         output_dict = copy_data_files('temp_test_copy_data_file',
-                                      file_dict)
+                                      file_dict,
+                                      rsmtool_test_dir)
         for file_type in expected_dict:
             eq_(output_dict[file_type], expected_dict[file_type])
             ok_(Path(output_dict[file_type]).exists())
             ok_(Path(output_dict[file_type]).is_file())
-
 
     def test_copy_data_files_directory(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups'}
         expected_dict = {'exp_dir': 'temp_test_copy_dirs/lr-subgroups'}
         self.dirs_to_remove.append('temp_test_copy_dirs')
         output_dict = copy_data_files('temp_test_copy_dirs',
-                                      file_dict)
+                                      file_dict,
+                                      rsmtool_test_dir)
         for file_type in expected_dict:
             eq_(output_dict[file_type], expected_dict[file_type])
             ok_(Path(output_dict[file_type]).exists())
             ok_(Path(output_dict[file_type]).is_dir())
-
 
     def test_copy_data_files_files_and_directories(self):
         file_dict = {'exp_dir': 'data/experiments/lr-self-compare/lr-subgroups',
@@ -49,7 +58,8 @@ class TestCopyData():
                          'test': 'temp_test_copy_mixed/test.csv'}
         self.dirs_to_remove.append('temp_test_copy_mixed')
         output_dict = copy_data_files('temp_test_copy_mixed',
-                                      file_dict)
+                                      file_dict,
+                                      rsmtool_test_dir)
         for file_type in expected_dict:
             eq_(output_dict[file_type], expected_dict[file_type])
             ok_(Path(output_dict[file_type]).exists())


### PR DESCRIPTION
[This line](https://github.com/EducationalTestingService/rsmtool/blob/master/rsmtool/test_utils.py#L34) that computes `rsmtool_test_dir` basically assumes that the tests are always being run from the RSMTool source code directory. However, this is not true when we are testing the conda/pip packages (which do not include the tests). We currently use the `TESTDIR` environment variable to get around this but this does not always work as this PR shows (many of the tests still rely on `rsmtool_test_dir` directly). However, for now, this PR provides a fix for such tests.

This PR:

1. Add the missing test file `test_test_utils.py` to Travis and Azure builds.
2. Modify `copy_data_files()` and some other test functions to explicitly specify `rsmtool_test_dir`so that the tests pass when running the tests with packages.
3. Includes `rsmtool/test_utils.py` for coverage checking – it was being excluded until now.
4. A few other fixes (e.g., Windows path issues, extra slashes etc.) to get the tests to pass.

I discovered these issues when testing packages through the pip and conda testing builds which were failing. With these changes, the builds now pass as seen below (I modified those builds to check out this branch temporarily instead of `master`):

[pip package on windows](https://dev.azure.com/EducationalTestingService/web/build.aspx?pcguid=f4f8d738-e70a-421a-9cc1-983ff2abe8d4&builduri=vstfs%3a%2f%2f%2fBuild%2fBuild%2f335)
[pip package on linux](https://travis-ci.org/EducationalTestingService/rsmtool-pip-tester/builds/654077330)
[conda package on windows](https://dev.azure.com/EducationalTestingService/web/build.aspx?pcguid=f4f8d738-e70a-421a-9cc1-983ff2abe8d4&builduri=vstfs%3a%2f%2f%2fBuild%2fBuild%2f336)
[conda package on linux](https://travis-ci.org/EducationalTestingService/rsmtool-conda-tester/builds/654077419)

Once this PR is merged, I will re-run the package builds and then submit the release branch PR.

**Note**: the decrease in coverage is expected since we’re now including `test_utils.py`.  