### PR TITLE
Allow run functions to accept pathlib.Path objects

### DIFF
--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -1411,13 +1411,13 @@ class ConfigurationParser:
 
             # read configuration from file
             configuration = self.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                              context=context)
+                                                                            context=context)
 
         elif isinstance(config_file_or_obj_or_dict, dict):
 
             # read configuration from dictionary
             configuration = self.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                                context=context)
+                                                                              context=context)
 
         elif isinstance(config_file_or_obj_or_dict, Configuration):
 

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -786,6 +786,8 @@ class ConfigurationParser:
         ValueError
             If config file is not .json or .cfg.
         """
+        # If we received a path to a file,
+        # let's convert it to Path
         if isinstance(config_file_or_obj_or_dict, Path):
             filepath = config_file_or_obj_or_dict
         elif isinstance(config_file_or_obj_or_dict, str):
@@ -794,7 +796,8 @@ class ConfigurationParser:
         else:
             return ConfigurationParser(*args, **kwargs)
 
-        # Get the file extension
+        # For files we initialize one of the subclasses.
+        # Get the file extension to determine which.
         extension = filepath.suffix
         if extension.lower() not in CONFIG_TYPE:
             raise ValueError('Configuration file must be '

--- a/rsmtool/rsmcompare.py
+++ b/rsmtool/rsmcompare.py
@@ -91,7 +91,7 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
 
     logger = logging.getLogger(__name__)
 
-        # initialize a correct configparser
+    # initialize a correct configparser
     parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
     # create a configuration object from input
     configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict,

--- a/rsmtool/rsmcompare.py
+++ b/rsmtool/rsmcompare.py
@@ -69,7 +69,7 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or Dictionary
+    config_file_or_obj_or_dict : str or pathlib.Path or Configuration or Dictionary
         Path to the experiment configuration file.
         Users can also pass a `Configuration` object that is in memory
         or a Python dictionary with keys corresponding to fields in the
@@ -91,38 +91,11 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
 
     logger = logging.getLogger(__name__)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmcompare')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmcompare')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_comparison must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
-
+        # initialize a correct configparser
+    parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
+    # create a configuration object from input
+    configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict,
+                                                                   context='rsmcompare')
     logger.info('Saving configuration file.')
     configuration.save(output_dir)
 

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -67,37 +67,11 @@ def run_evaluation(config_file_or_obj_or_dict, output_dir):
     os.makedirs(figdir, exist_ok=True)
     os.makedirs(reportdir, exist_ok=True)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmeval')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmeval')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_evaluation must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
+    # initialize a correct configparser
+    parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
+    # create a configuration object from input
+    configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict,
+                                                                   context='rsmeval')
 
     logger.info('Saving configuration file.')
     configuration.save(output_dir)

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -36,7 +36,7 @@ def run_evaluation(config_file_or_obj_or_dict, output_dir):
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or Dictionary
+    config_file_or_obj_or_dict : str or pathlib.Path or Configuration or Dictionary
         Path to the experiment configuration file.
         Users can also pass a `Configuration` object that is in memory
         or a Python dictionary with keys corresponding to fields in the

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -65,38 +65,11 @@ def compute_and_save_predictions(config_file_or_obj_or_dict,
 
     logger = logging.getLogger(__name__)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmpredict')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmpredict')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to compute_and_save_predictions must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
-
+    # initialize a correct configparser
+    parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
+    # create a configuration object from input
+    configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict,
+                                                                   context='rsmpredict')
     # get the experiment ID
     experiment_id = configuration['experiment_id']
 

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -43,7 +43,7 @@ def compute_and_save_predictions(config_file_or_obj_or_dict,
 
     Parameters
     ----------
-    config_file_or_obj : str or configuration_parser.Configuration
+    config_file_or_obj : str or pathlib.Path or Configuration or Dictionary
         Path to the experiment configuration file.
         Users can also pass a `Configuration` object that is in memory.
         Relative paths in the configuration file will be interpreted relative

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -99,7 +99,7 @@ def run_summary(config_file_or_obj_or_dict,
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or dict
+    config_file_or_obj_or_dict : str or pathlib.Path or Configuration or Dictionary
         Path to the experiment configuration file.
         Users can also pass a `Configuration` object that is in memory
         or a Python dictionary with keys corresponding to fields in the

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -131,39 +131,11 @@ def run_summary(config_file_or_obj_or_dict,
     os.makedirs(figdir, exist_ok=True)
     os.makedirs(reportdir, exist_ok=True)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmsummarize')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmsummarize')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_summary must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
-    logger.info('Saving configuration file.')
-    configuration.save(output_dir)
+    # initialize a correct configparser
+    parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
+    # create a configuration object from input
+    configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict,
+                                                                   context='rsmsummarize')
 
     # get the list of the experiment dirs
     experiment_dirs = configuration['experiment_dirs']

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -74,35 +74,9 @@ def run_experiment(config_file_or_obj_or_dict,
     makedirs(figdir, exist_ok=True)
     makedirs(reportdir, exist_ok=True)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
+    parser = ConfigurationParser()
 
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict)
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict)
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_experiment must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
+    configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict)
 
     logger.info('Saving configuration file.')
     configuration.save(output_dir)

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -36,7 +36,7 @@ def run_experiment(config_file_or_obj_or_dict,
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or Dictionary
+    config_file_or_obj_or_dict : str or pathlib.Path or Configuration or Dictionary
         Path to the experiment configuration file.
         Users can also pass a `Configuration` object that is in memory
         or a Python dictionary with keys corresponding to fields in the
@@ -74,8 +74,9 @@ def run_experiment(config_file_or_obj_or_dict,
     makedirs(figdir, exist_ok=True)
     makedirs(reportdir, exist_ok=True)
 
-    parser = ConfigurationParser()
-
+    # initialize a correct configparser
+    parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
+    # create a configuration object from input
     configuration = parser.get_configuration_from_file_obj_or_dict(config_file_or_obj_or_dict)
 
     logger.info('Saving configuration file.')

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -237,6 +237,12 @@ ID_FIELDS = {'rsmtool': 'experiment_id',
 
 _skll_module = import_module('skll.learner')
 
+CONTEXT_TO_FUNCTION = {'rsmtool': 'run_experiment',
+                       'rsmeval': 'run_evaluation',
+                       'rsmsummarize': 'run_summary',
+                       'rsmcompare': 'run_comparison',
+                       'rsmpredict': 'compute_and_save_predictions'}
+
 
 def is_skll_model(model_name):
     """

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -9,6 +9,8 @@ from io import StringIO
 from os import getcwd
 from os.path import abspath, dirname, join
 
+from pathlib import Path
+
 from shutil import rmtree
 
 from numpy.testing import assert_array_equal
@@ -565,6 +567,18 @@ class TestConfigurationParser:
     def test_get_correct_configparser_json(self):
         config_parser = ConfigurationParser.get_configparser('config.json')
         assert isinstance(config_parser, JSONConfigurationParser)
+
+    def test_get_correct_configparser_dict(self):
+        config_parser = ConfigurationParser.get_configparser({'config': 'value'})
+        assert isinstance(config_parser, ConfigurationParser)
+
+    def test_get_correct_configparser_path(self):
+        config_parser = ConfigurationParser.get_configparser(Path('config.json'))
+        assert isinstance(config_parser, JSONConfigurationParser)
+
+    @raises(ValueError)
+    def test_get_correct_configparser_wrong_extension(self):
+        config_parser = ConfigurationParser.get_configparser('config.txt')
 
 
 class TestConfiguration:

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -578,7 +578,7 @@ class TestConfigurationParser:
 
     @raises(ValueError)
     def test_get_correct_configparser_wrong_extension(self):
-        config_parser = ConfigurationParser.get_configparser('config.txt')
+        ConfigurationParser.get_configparser('config.txt')
 
 
 class TestConfiguration:


### PR DESCRIPTION
This PR addresses #384. 
- I refactored the code since the input processing part was shared by all components: this is now done via Configuration Parser method. 
- The path to the config file can be passed as either string or pathlib.Path object. Previously the latter functionality was available as undocumented option. 
- I didn't add new tests for that method since the functionality is already tested in tests we wrote for individual components
