### PR TITLE
Refactor `configuration_parser.py`

### DIFF
--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -19,6 +19,7 @@ from copy import copy, deepcopy
 from collections import Counter
 from configparser import ConfigParser
 from os import getcwd
+from os.path import abspath
 
 from pathlib import Path
 from ruamel import yaml
@@ -386,7 +387,10 @@ class Configuration:
 
         if new_path is None:
             raise ValueError("The `configdir` attribute cannot be set to `None` ")
-        self._configdir = Path(new_path).resolve()
+
+        # TODO: replace `Path(abspath(new_path))` with `Path(new_path).resolve()
+        # once this Windows bug is fixed: https://bugs.python.org/issue38671
+        self._configdir = Path(abspath(new_path))
 
     @property
     def filename(self):

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -90,15 +90,15 @@ def deprecated_positional_argument():
     return decorator
 
 
-def configure(tool_name, config_file_or_obj_or_dict):
+def configure(context, config_file_or_obj_or_dict):
     """
-    Get the configuration for ``tool_name`` from the input
+    Get the configuration for ``context`` from the input
     ``config_file_or_obj_or_dict``.
 
     Parameters
     ----------
-    tool_name : str
-        The name of the tool that is being configured. Must be one of
+    context : str
+        The context that is being configured. Must be one of
         ``rsmtool``, ``rsmeval``, ``rsmcompare``, ``rsmsummarize``, or
         ``rsmpredict``.
     config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
@@ -131,13 +131,13 @@ def configure(tool_name, config_file_or_obj_or_dict):
 
         # Instantiate configuration parser object
         parser = ConfigurationParser(config_file_or_obj_or_dict)
-        configuration = parser.parse(context=tool_name)
+        configuration = parser.parse(context=context)
 
     elif isinstance(config_file_or_obj_or_dict, dict):
 
         # directly instantiate the Configuration from the dictionary
         configuration = Configuration(config_file_or_obj_or_dict,
-                                      context=tool_name)
+                                      context=context)
 
     elif isinstance(config_file_or_obj_or_dict, Configuration):
 
@@ -322,15 +322,19 @@ class Configuration:
         filepath : str
             The path for the config file.
         """
+
+        # raise a deprecation warning first
+        warnings.warn("The `filepath` attribute of the Configuration "
+                      "object will be removed in RSMTool v8.0."
+                      "Use the `configdir` and `filename` attributes "
+                      "if you need the full path to the "
+                      "configuration file", DeprecationWarning)
+
+        # then compute the deprecated attribute if we can
         if not self.filename:
             raise AttributeError('The `filepath` attribute is not defined '
                                  'for this Configuration object.')
         else:
-            warnings.warn("The `filepath` attribute of the Configuration "
-                          "object will be removed in RSMTool v8.0."
-                          "Use the `configdir` and `filename` attributes "
-                          "if you need the full path to the "
-                          "configuration file", DeprecationWarning)
             filepath = join(self.configdir, self.filename)
             return filepath
 
@@ -973,7 +977,7 @@ class ConfigurationParser:
             A Configuration object containing the parameters in the
             file that we instantiated the parser for.
         """
-        _, extension = splitext(self._filename)
+        extension = Path(self._filename).suffix.lower()
         filepath = join(self._configdir, self._filename)
         if extension == '.json':
             configdict = self._parse_json_file(filepath)

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -550,7 +550,7 @@ class Configuration:
             output_dir = Path(getcwd())
 
         # Create output directory, if it does not exist
-        output_dir = output_dir / 'output'
+        output_dir = Path(output_dir) / 'output'
         output_dir.mkdir(exist_ok=True)
 
         id_field = ID_FIELDS[self._context]

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -136,7 +136,8 @@ def configure(tool_name, config_file_or_obj_or_dict):
     elif isinstance(config_file_or_obj_or_dict, dict):
 
         # directly instantiate the Configuration from the dictionary
-        configuration = Configuration(dict)
+        configuration = Configuration(config_file_or_obj_or_dict,
+                                      context=tool_name)
 
     elif isinstance(config_file_or_obj_or_dict, Configuration):
 

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -25,7 +25,7 @@ from os.path import (abspath,
                      dirname,
                      join,
                      splitext)
-
+from pathlib import Path
 from ruamel import yaml
 
 from rsmtool import HAS_RSMEXTRA
@@ -90,6 +90,76 @@ def deprecated_positional_argument():
     return decorator
 
 
+def configure(tool_name, config_file_or_obj_or_dict):
+    """
+    Get the configuration for ``tool_name`` from the input
+    ``config_file_or_obj_or_dict``.
+
+    Parameters
+    ----------
+    tool_name : str
+        The name of the tool that is being configured. Must be one of
+        ``rsmtool``, ``rsmeval``, ``rsmcompare``, ``rsmsummarize``, or
+        ``rsmpredict``.
+    config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
+        Path to the experiment configuration file either a a string
+        or as a ``pathlib.Path`` object. Users can also pass a
+        ``Configuration`` object that is in memory or a Python dictionary
+        with keys corresponding to fields in the configuration file. Given a
+        configuration file, any relative paths in the configuration file
+        will be interpreted relative to the location of the file. Given a
+        ``Configuration`` object, relative paths will be interpreted
+        relative to the ``configdir`` attribute, that _must_ be set. Given
+        a dictionary, the reference path is set to the current directory.
+
+    Returns
+    -------
+    configuration : Configuration
+        The Configuration object for the tool.
+
+    Raises
+    ------
+    AttributeError
+        If the ``configdir`` attribute for the Configuration input is not set.
+    ValueError
+        If ``config_file_or_obj_or_dict`` contains anything except a string,
+        a path, a dictionary, or a ``Configuration`` object.
+    """
+    # check what sort of input we got
+    # if we got a string we consider this to be path to config file
+    if isinstance(config_file_or_obj_or_dict, (str, Path)):
+
+        # Instantiate configuration parser object
+        parser = ConfigurationParser(config_file_or_obj_or_dict)
+        configuration = parser.parse(context=tool_name)
+
+    elif isinstance(config_file_or_obj_or_dict, dict):
+
+        # directly instantiate the Configuration from the dictionary
+        configuration = Configuration(dict)
+
+    elif isinstance(config_file_or_obj_or_dict, Configuration):
+
+        # raise an error if we are passed a Configuration object
+        # without a configdir attribute. This can only
+        # happen if the object was constructed using an earlier version
+        # of RSMTool and stored
+        try:
+            assert config_file_or_obj_or_dict.configdir is not None
+        except AssertionError:
+            raise AttributeError("Configuration object must have configdir attribute.")
+        else:
+            configuration = config_file_or_obj_or_dict
+
+    else:
+        raise ValueError("The input to run_experiment must be "
+                         "a path to the file (str), a dictionary, "
+                         "or a configuration object. You passed "
+                         "{}.".format(type(config_file_or_obj_or_dict)))
+
+    return configuration
+
+
 class Configuration:
     """
     Configuration class, which encapsulates all of the
@@ -99,7 +169,7 @@ class Configuration:
 
     @deprecated_positional_argument()
     def __init__(self,
-                 config_dict,
+                 configdict,
                  *,
                  configdir=None,
                  filename=None,
@@ -107,18 +177,13 @@ class Configuration:
         """
         Create an object of the `Configuration` class.
 
-        Note that usually the Configuration
-        object used for RSMTool experiments is created using
-        `ConfigurationParser.load_normalize_and_validate_config_from_dict()` or
-        `ConfigurationParser.read_normalize_validate_and_process_config()`.
-        You should directly instantiate a Configuration object only if
-        you already have a normalized configuration dictionary
+        This method should be used to directly instantiate a Configuration
+        object only if you already have a normalized configuration dictionary
         (e.g., from previous RSMTool experiments).
-
 
         Parameters
         ----------
-        config_dict : dict
+        configdict : dict
             A dictionary of configuration parameters.
             The dictionary must be a valid configuration dictionary
             with default values filled as necessary.
@@ -140,8 +205,13 @@ class Configuration:
             Defaults to 'rsmtool'.
         """
 
-        self._config = config_dict
-        self._context = context
+        if not isinstance(configdict, dict):
+            raise TypeError('The input must be a dictionary.')
+
+        # normalize, process and validate the configuration dictionary
+        configdict = ConfigurationParser.normalize_config(configdict)
+        configdict = ConfigurationParser.process_config(configdict)
+        configdict = ConfigurationParser.validate_config(configdict, context=context)
 
         # set configdir to `cwd` if not given and let the user know
         if configdir is None:
@@ -150,8 +220,10 @@ class Configuration:
         else:
             configdir = abspath(configdir)
 
+        self._config = configdict
         self._configdir = configdir
         self._filename = filename
+        self._context = context
 
     def __contains__(self, key):
         """
@@ -249,13 +321,17 @@ class Configuration:
         filepath : str
             The path for the config file.
         """
-        warnings.warn("The `filepath` attribute of the Configuration "
-                      "object will be removed in RSMTool v8.0."
-                      "Use the `configdir` and `filename` attributes if you "
-                      "need the full path to the "
-                      "configuration file", DeprecationWarning)
-        filepath = join(self.configdir, self.filename)
-        return filepath
+        if not self.filename:
+            raise AttributeError('The `filepath` attribute is not defined '
+                                 'for this Configuration object.')
+        else:
+            warnings.warn("The `filepath` attribute of the Configuration "
+                          "object will be removed in RSMTool v8.0."
+                          "Use the `configdir` and `filename` attributes "
+                          "if you need the full path to the "
+                          "configuration file", DeprecationWarning)
+            filepath = join(self.configdir, self.filename)
+            return filepath
 
     @filepath.setter
     def filepath(self, new_path):
@@ -730,162 +806,158 @@ class Configuration:
 
 class ConfigurationParser:
     """
-    A `ConfigurationParser` class to create a
-    `Configuration` object.
+    A `ConfigurationParser` class to create a `Configuration` object.
     """
 
-    def __init__(self):
-
-        # Set configuration object to None
-        self._config = None
-        self._filename = None
-        self._configdir = None
-
-    def _check_config_is_loaded(self):
+    def __init__(self, pathlike):
         """
-        Check to make sure a configuration file
-        or dictionary was loaded; otherwise,
-        raise ``NameError``.
-
-        Raises
-        ------
-        NameError
-            If no configuration file or dictionary was loaded.
-        """
-        if self._config is None:
-            raise NameError('No configuration file was loaded '
-                            'Make sure to load a configuration file '
-                            'from a dict using the `load_config_from_dict()` '
-                            'method or use the `read_config_from_file()` method '
-                            'with the appropriate sub-class object to read from '
-                            'a file. You can use the `get_configparser` class '
-                            'method to instantiate the appropriate sub-class '
-                            'object for reading either `.json` or `.cfg` files.')
-
-
-    @classmethod
-    def get_configparser(cls, filepath, *args, **kwargs):
-        """
-        Get the correct `ConfigurationParser` object,
-        based on the file extension.
+        Instantiate a ConfigurationParser for a given config file path.
 
         Parameters
         ----------
-        filepath : str
-            The path to the configuration file.
-
-        Returns
-        -------
-        config : ConfigurationParser
-            The configuration parser object.
+        pathlike : str or pathlib.Path
+            A string containing the path to the configuration file
+            that is to be parsed. A ``pathlib.Path`` instance is also
+            acceptable.
 
         Raises
         ------
         ValueError
-            If config file is not .json or .cfg.
+            If the configuration file does not have a valid extension.
+            Valid extensions are ``.json`` and ``.cfg``.
         """
-        _, extension = splitext(filepath)
-        if extension.lower() not in CONFIG_TYPE:
+        # if we passed in a string, convert it to a Path
+        if isinstance(pathlike, str):
+            pathlike = Path(pathlike)
+
+        # make sure have either a JSON or CFG configuration file
+        extension = pathlike.suffix.lower()
+        if extension not in ['.json', '.cfg']:
             raise ValueError('Configuration file must be '
                              'in either `.json` or `.cfg`'
                              'format. You specified: {}.'.format(extension))
 
-        return CONFIG_TYPE[extension.lower()](*args, **kwargs)
+        # set the various attributes to None
+        self._config = None
+        self._filename = pathlike.name
+        self._configdir = pathlike.resolve().parent
 
     @staticmethod
-    def check_id_fields(id_field_values):
+    def _fix_json(json_string):
         """
-        Check whether the ID fields in the given dictionary
-        are properly formatted, i.e., they ::
-        - do not contain any spaces
-        - are shorter than 200 characters
+        Takes a bit of JSON that might have bad quotes
+        or capitalized booleans and fixes that stuff.
 
         Parameters
         ----------
-        id_field_values : dict
-            A dictionary containing the ID fields names
-            as the keys and the value from the configuration
-            file as the value.
+        json_string : str
+            A string to be reformatted for JSON parsing.
+
+        Return
+        ------
+        json_string : str
+            The updated string.
+        """
+        json_string = json_string.replace('True', 'true')
+        json_string = json_string.replace('False', 'false')
+        json_string = json_string.replace("'", '"')
+        return json_string
+
+    def _parse_json_file(self, filepath):
+        """
+        A private method to parse JSON configuration files and return
+        a Python dictionary.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the JSON configuration file.
+
+        Returns
+        -------
+        configdict : dict
+            A Python dictionary containing the parameters from the
+            JSON configuration file.
 
         Raises
         ------
         ValueError
-            If the values for the ID fields in the given
-            dictionary are not formatted correctly.
+            If the JSON file could not be parsed.
         """
+        try:
+            configdict = parse_json_with_comments(filepath)
+        except ValueError:
+            raise ValueError('The main configuration file `{}` exists but '
+                             'is formatted incorrectly. Please check that '
+                             'each line ends with a comma, there is no comma '
+                             'at the end of the last line, and that all quotes '
+                             'match.'.format(filepath))
 
-        for id_field, id_field_value in id_field_values.items():
-            if len(id_field_value) > 200:
-                raise ValueError("{} is too long (must be "
-                                 "<=200 characters)".format(id_field))
+        return configdict
 
-            if re.search(r'\s', id_field_value):
-                raise ValueError("{} cannot contain any "
-                                 "spaces".format(id_field))
-
-    def load_config_from_dict(self,
-                              config_dict,
-                              configdir=None):
+    def _parse_cfg_file(self, filepath):
         """
-        Load configuration dictionary.
+        A private method to parse INI-style configuration files and
+        return a Python dictionary
 
         Parameters
         ----------
-        config_dict : dict
-            A dictionary containing the configuration
-            parameters to parse.
-        configdir : str, optional
-            Path to the reference directory used to resolve
-            any relative path in the dictionary. If not specified,
-            the current working directory will be used.
-        filename: str, optional
+        filepath : str
+            Path to the CFG configuration file.
 
+        Returns
+        -------
+        configdict : dict
+            A Python dictionary containing the parameters from the
+            CFG configuration file.
 
         Raises
         ------
-        TypeError
-            If `config_dict` is not a ``dict``
-        AttributeError
-            If config has already been assigned.
+        ValueError
+            If the configuration file could not be read or parsed.
         """
-        if not isinstance(config_dict, dict):
-            raise TypeError('The `config_dict` must be a dictionary.')
+        # Get the `ConfigParser` object
+        py_config_parser = ConfigParser()
 
-        if self._config is None:
-            self._config = config_dict
-        else:
-            raise AttributeError('A configuration dictionary has already'
-                                 'been assigned. You cannot assign another'
-                                 'dictionary.')
+        # Try to read main configuration file.
+        try:
+            py_config_parser.read(filepath)
+        except Exception as error:
+            raise ValueError('Main configuration file '
+                             'could not be read: {}'.format(error))
 
-        if configdir is None:
-            configdir = getcwd()
+        configdict = {}
 
-        self._configdir = abspath(configdir)
-        logging.info("Configuration directory will be set to {}".format(self._configdir))
+        # Loop through all sections of the ConfigParser
+        # object and add items to the dictionary
+        for section in py_config_parser.sections():
+            for name, value in py_config_parser.items(section):
 
-        # set filename to none since there was no configuration file.
-        # If the user for some reason wants
-        # to set it, they can do so explicitly.
-        self._filename = None
+                # Check if the key already exists in the config dictionary.
+                # If it does, skip it and log a warning.
+                if name in configdict:
+                    logging.warning('There are duplicate keys for `{}`'
+                                    'in the configuration file. Only '
+                                    'the first instance will be '
+                                    'included.'.format(name))
+                    continue
 
+                # Otherwise, safe convert the value
+                # and add it to the dictionary.
+                else:
+                    value = self._fix_json(value)
+                    value = yaml.safe_load(value)
+                    configdict[name] = value
 
-    def load_normalize_and_validate_config_from_dict(self,
-                                                     config_dict,
-                                                     configdir=getcwd(),
-                                                     context='rsmtool'):
+        return configdict
+
+    def parse(self, context='rsmtool'):
         """
-        Load configuration dictionary.
+        Parse the configuration file for which this parser was
+        instantiated.
 
         Parameters
         ----------
-        config_dict : dict
-            A dictionary containing the configuration
-            parameters to parse.
-        configdir : str, optional
-            Path to the reference directory used to resolve
-            any relative path in the dictionary.
-            Defaults to the current working directory.
         context : str, optional
             Context of the tool in which we are validating.
             Possible values are ::
@@ -897,41 +969,33 @@ class ConfigurationParser:
 
         Returns
         -------
-        config_obj : Configuration
-            A configuration object
+        configuration : Configuration
+            A Configuration object containing the parameters in the
+            file that we instantiated the parser for.
         """
-        self.load_config_from_dict(config_dict, configdir)
-        return self.normalize_validate_and_process_config(context=context)
+        _, extension = splitext(self._filename)
+        filepath = join(self._configdir, self._filename)
+        if extension == '.json':
+            configdict = self._parse_json_file(filepath)
+        else:
+            configdict = self._parse_cfg_file(filepath)
 
+        # normalize, process and validate the configuration dictionary
+        configdict = ConfigurationParser.normalize_config(configdict)
+        configdict = ConfigurationParser.process_config(configdict)
+        configdict = ConfigurationParser.validate_config(configdict, context=context)
 
+        self._config = configdict
 
+        return Configuration(self._config,
+                             configdir=self._configdir,
+                             filename=self._filename,
+                             context=context)
 
-    def read_config_from_file(self, filepath):
+    @classmethod
+    def normalize_config(cls, config):
         """
-        Read the configuration file.
-
-        Parameters
-        ----------
-        filepath : str
-            The path to the configuration file.
-
-        Raises
-        ------
-        NotImplementedError
-            This method must be implemented in subclass.
-        """
-        raise NotImplementedError("The method `read_config_from_file()` "
-                                  "is only implemented in the subclasses "
-                                  "``CFGConfigurationParser`` and "
-                                  "``JSONConfigurationParser``. "
-                                  "You can use the class method "
-                                  "`get_configparser()` to retrieve "
-                                  "the correct configuration parser object "
-                                  "for parsing JSON or CFG files.")
-
-    def normalize_config(self, inplace=True):
-        """
-        Normalize the field names in `self._config` or `config` in order to
+        Normalize the field names in `config` in order to
         maintain backwards compatibility with old configuration files.
 
         Parameters
@@ -952,13 +1016,6 @@ class ConfigurationParser:
             If no JSON configuration object exists, or if value passed for
             `use_scaled_predictions` is in the wrong format.
         """
-
-        # Check to make sure a configuration file
-        # or dictionary has been loaded.
-        self._check_config_is_loaded()
-
-        # Get the parameter dictionary
-        config = self._config
 
         # Create a new JSON object with the normalized field names
         new_config = {}
@@ -1014,13 +1071,10 @@ class ConfigurationParser:
                               category=DeprecationWarning)
                 new_config['model'] = norm_model_name
 
-        if inplace:
-            self._config = new_config
-        return Configuration(self._config,
-                             configdir=self._configdir,
-                             filename=self._filename,)
+        return new_config
 
-    def validate_config(self, context='rsmtool', inplace=True):
+    @classmethod
+    def validate_config(cls, config, context='rsmtool'):
         """
         Ensure that all required fields are specified, add default values
         values for all unspecified fields, and ensure that all specified
@@ -1052,12 +1106,8 @@ class ConfigurationParser:
             If config does not exist, and no config passed.
         """
 
-        # Check to make sure a configuration file
-        # or dictionary has been loaded.
-        self._check_config_is_loaded()
-
-        # Get the parameter dictionary
-        new_config = self._config
+        # make a copy of the given parameter dictionary
+        new_config = deepcopy(config)
 
         # 1. Check to make sure all required fields are specified
         required_fields = CHECK_FIELDS[context]['required']
@@ -1082,11 +1132,19 @@ class ConfigurationParser:
                                  " in json file".format(field))
 
         # 4. Check to make sure that the ID fields that will be
-        # used as part of filenames formatted correctly
+        # used as part of filenames are formatted correctly
+        # i.e., they do not contain any spaces and are < 200 characters
         id_field = ID_FIELDS[context]
         id_field_values = {id_field: new_config[id_field]}
 
-        self.check_id_fields(id_field_values)
+        for id_field, id_field_value in id_field_values.items():
+            if len(id_field_value) > 200:
+                raise ValueError("{} is too long (must be "
+                                 "<=200 characters)".format(id_field))
+
+            if re.search(r'\s', id_field_value):
+                raise ValueError("{} cannot contain any "
+                                 "spaces".format(id_field))
 
         # 5. Check that the feature file and feature subset/subset file are not
         # specified together
@@ -1226,13 +1284,10 @@ class ConfigurationParser:
         new_config = {k: v for k, v in new_config.items()
                       if k in context_relevant_fields}
 
-        if inplace:
-            self._config = new_config
-        return Configuration(self._config,
-                             configdir=self._configdir,
-                             filename=self._filename,)
+        return new_config
 
-    def process_config(self, inplace=True):
+    @classmethod
+    def process_config(cls, config):
         """
         Converts fields which are read in as string to the
         appropriate format. Fields which can take multiple
@@ -1257,12 +1312,8 @@ class ConfigurationParser:
             If config does not exist, or no config read.
         """
 
-        # Check to make sure a configuration file
-        # or dictionary has been loaded.
-        self._check_config_is_loaded()
-
         # Get the parameter dictionary
-        new_config = self._config
+        new_config = deepcopy(config)
 
         # convert multiple values into lists
         for field in LIST_FIELDS:
@@ -1288,204 +1339,4 @@ class ConfigurationParser:
                         bool_value = json.loads(m.group().lower())
                         new_config[field] = bool_value
 
-        if inplace:
-            self._config = new_config
-        return Configuration(self._config,
-                             configdir=self._configdir,
-                             filename=self._filename,)
-
-    def normalize_validate_and_process_config(self, context='rsmtool'):
-        """
-        Normalize, validate, and process data from a config file.
-
-        Parameters
-        ----------
-        context : str, optional
-            Context of the tool in which we are validating.
-            Possible values are ::
-
-                {'rsmtool', 'rsmeval',
-                 'rsmpredict', 'rsmcompare',
-                 'rsmsummarize'}
-
-            Defaults to 'rsmtool'.
-
-        Returns
-        -------
-        config_obj : Configuration
-            A configuration object
-
-        Raises
-        -------
-        NameError
-            If config does not exist, or no config read.
-        """
-
-        # Check to make sure a configuration file
-        # or dictionary has been loaded.
-        self._check_config_is_loaded()
-
-        self.normalize_config()
-        self.process_config()
-        self.validate_config(context=context)
-        return Configuration(self._config,
-                             configdir=self._configdir,
-                             filename=self._filename,
-                             context=context)
-
-    def read_normalize_validate_and_process_config(self,
-                                                   filepath,
-                                                   context='rsmtool'):
-        """
-        Read, normalize, validate, and process data from a config file.
-
-        Parameters
-        ----------
-        filepath : str
-            The path to the configuration file.
-        context : str, optional
-            Context of the tool in which we are validating.
-            Possible values are ::
-
-                {'rsmtool', 'rsmeval',
-                 'rsmpredict', 'rsmcompare', 'rsmsummarize'}
-
-            Defaults to 'rsmtool'.
-
-        Returns
-        -------
-        config_obj : Configuration
-            A configuration object
-        """
-
-        logging.info('Reading and preprocessing configuration file: {}'.format(filepath))
-        self.read_config_from_file(filepath)
-        return self.normalize_validate_and_process_config(context=context)
-
-
-class JSONConfigurationParser(ConfigurationParser):
-    """
-    A subclass of `ConfigurationParser` for parsing
-    JSON-style config files.
-    """
-
-    def __init__(self):
-
-        super().__init__()
-
-    def read_config_from_file(self, filepath):
-        """
-        Read the configuration file.
-
-        Parameters
-        ----------
-        filepath : str
-            The path to the configuration file.
-
-        Raises
-        ------
-        ValueError
-            If main configuration file is improperly formatted.
-        """
-        try:
-            config = parse_json_with_comments(filepath)
-        except ValueError:
-            raise ValueError('The main configuration file `{}` exists but '
-                             'is formatted incorrectly. Please check that '
-                             'each line ends with a comma, there is no comma '
-                             'at the end of the last line, and that all quotes '
-                             'match.'.format(filepath))
-
-        self._config = config
-        self._filename = basename(filepath)
-        self._configdir = dirname(abspath(filepath))
-
-
-class CFGConfigurationParser(ConfigurationParser):
-    """
-    A subclass of `ConfiguraitonParser` for parsing
-    Microsoft INI-style config files.
-    """
-
-    def __init__(self):
-
-        super().__init__()
-
-    @staticmethod
-    def _fix_json(json_string):
-        """
-        Takes a bit of JSON that might have bad quotes
-        or capitalized booleans and fixes that stuff.
-
-        Parameters
-        ----------
-        json_string : str
-            A string to be reformatted for JSON parsing.
-
-        Return
-        ------
-        json_string : str
-            The updated string.
-        """
-        json_string = json_string.replace('True', 'true')
-        json_string = json_string.replace('False', 'false')
-        json_string = json_string.replace("'", '"')
-        return json_string
-
-    def read_config_from_file(self, filepath):
-        """
-        Read the configuration file.
-
-        Parameters
-        ----------
-        filepath : str
-            The path to the configuration file.
-
-        Raises
-        ------
-        ValueError
-            If main configuration file is improperly formatted.
-        """
-
-        # Get the `ConfigParser` object
-        py_config_parser = ConfigParser()
-
-        # Try to read main configuration file.
-        try:
-            py_config_parser.read(filepath)
-        except Exception as error:
-            raise ValueError('Main configuration file '
-                             'could not be read: {}'.format(error))
-
-        config = {}
-
-        # Loop through all sections of the ConfigParser
-        # object and add items to the dictionary
-        for section in py_config_parser.sections():
-            for name, value in py_config_parser.items(section):
-
-                # Check if the key already exists in the config dictionary.
-                # If it does, skip it and log a warning.
-                if name in config:
-                    logging.warning('There are duplicate keys for `{}`'
-                                    'in the configuration file. Only '
-                                    'the first instance will be '
-                                    'included.'.format(name))
-                    continue
-
-                # Otherwise, safe convert the value
-                # and add it to the dictionary.
-                else:
-
-                    value = self._fix_json(value)
-                    value = yaml.safe_load(value)
-                    config[name] = value
-
-        self._config = config
-        self._filename = basename(filepath)
-        self._configdir = dirname(abspath(filepath))
-
-
-# Global config types
-CONFIG_TYPE = {'.cfg': CFGConfigurationParser,
-               '.json': JSONConfigurationParser}
+        return new_config

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -838,7 +838,6 @@ class ConfigurationParser:
                              'format. You specified: {}.'.format(extension))
 
         # set the various attributes to None
-        self._config = None
         self._filename = pathlike.name
         self._configdir = pathlike.resolve().parent
 
@@ -984,8 +983,6 @@ class ConfigurationParser:
         configdict = ConfigurationParser.normalize_config(configdict)
         configdict = ConfigurationParser.process_config(configdict)
         configdict = ConfigurationParser.validate_config(configdict, context=context)
-
-        self._config = configdict
 
         return Configuration(self._config,
                              configdir=self._configdir,

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -550,7 +550,7 @@ class Configuration:
             output_dir = Path(getcwd())
 
         # Create output directory, if it does not exist
-        output_dir = Path(output_dir) / 'output'
+        output_dir = Path(output_dir).resolve() / 'output'
         output_dir.mkdir(exist_ok=True)
 
         id_field = ID_FIELDS[self._context]

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -551,7 +551,7 @@ class Configuration:
 
         # Create output directory, if it does not exist
         output_dir = Path(output_dir).resolve() / 'output'
-        output_dir.mkdir(exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
         id_field = ID_FIELDS[self._context]
         experiment_id = self._config[id_field]

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -23,8 +23,7 @@ from os import getcwd, makedirs
 from os.path import (abspath,
                      basename,
                      dirname,
-                     join,
-                     splitext)
+                     join)
 from pathlib import Path
 from ruamel import yaml
 
@@ -874,8 +873,8 @@ class ConfigurationParser:
 
         Parameters
         ----------
-        filepath : str
-            Path to the JSON configuration file.
+        filepath : pathlib.Path
+            A ``pathlib.Path`` object containing the JSON configuration filepath.
 
         Returns
         -------
@@ -902,12 +901,12 @@ class ConfigurationParser:
     def _parse_cfg_file(self, filepath):
         """
         A private method to parse INI-style configuration files and
-        return a Python dictionary
+        return a Python dictionary.
 
         Parameters
         ----------
-        filepath : str
-            Path to the CFG configuration file.
+        filepath : pathlib.Path
+            A ``pathlib.Path`` object containing the CFG configuration filepath.
 
         Returns
         -------
@@ -978,7 +977,7 @@ class ConfigurationParser:
             file that we instantiated the parser for.
         """
         extension = Path(self._filename).suffix.lower()
-        filepath = join(self._configdir, self._filename)
+        filepath = self._configdir / self._filename
         if extension == '.json':
             configdict = self._parse_json_file(filepath)
         else:

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -984,7 +984,7 @@ class ConfigurationParser:
         configdict = ConfigurationParser.process_config(configdict)
         configdict = ConfigurationParser.validate_config(configdict, context=context)
 
-        return Configuration(self._config,
+        return Configuration(configdict,
                              configdir=self._configdir,
                              filename=self._filename,
                              context=context)

--- a/rsmtool/modeler.py
+++ b/rsmtool/modeler.py
@@ -1278,9 +1278,9 @@ class Modeler:
                                                    'trim_min',
                                                    'trim_tolerance'])
 
-        trim_max = configuration['trim_max']
-        trim_min = configuration['trim_min']
-        trim_tolerance = configuration['trim_tolerance']
+        (trim_min,
+         trim_max,
+         trim_tolerance) = configuration.get_trim_min_max_tolerance()
 
         predict_expected_scores = configuration['predict_expected_scores']
 

--- a/rsmtool/modeler.py
+++ b/rsmtool/modeler.py
@@ -1333,6 +1333,7 @@ class Modeler:
                     {'name': 'pred_test', 'frame': df_test_predictions},
                     {'name': 'postprocessing_params', 'frame': df_postproc_params}]
 
+        # configuration options that are entirely for internal use
         internal_options_dict = {'train_predictions_mean': train_predictions_mean,
                                  'train_predictions_sd': train_predictions_sd,
                                  'human_labels_mean': human_labels_mean,

--- a/rsmtool/modeler.py
+++ b/rsmtool/modeler.py
@@ -28,7 +28,6 @@ from rsmtool.analyzer import Analyzer
 from rsmtool.utils import compute_expected_scores_from_model, is_skll_model
 from rsmtool.preprocessor import FeaturePreprocessor
 
-from rsmtool.configuration_parser import Configuration
 from rsmtool.container import DataContainer
 from rsmtool.writer import DataWriter
 
@@ -1334,19 +1333,16 @@ class Modeler:
                     {'name': 'pred_test', 'frame': df_test_predictions},
                     {'name': 'postprocessing_params', 'frame': df_postproc_params}]
 
-        new_config_dict = {'train_predictions_mean': train_predictions_mean,
-                           'train_predictions_sd': train_predictions_sd,
-                           'human_labels_mean': human_labels_mean,
-                           'human_labels_sd': human_labels_sd}
+        internal_options_dict = {'train_predictions_mean': train_predictions_mean,
+                                 'train_predictions_sd': train_predictions_sd,
+                                 'human_labels_mean': human_labels_mean,
+                                 'human_labels_sd': human_labels_sd}
 
-        config_as_dict = configuration.to_dict()
-        config_as_dict.update(new_config_dict)
+        new_configuration = configuration.copy()
+        for key, value in internal_options_dict.items():
+            new_configuration[key] = value
 
-        configuration = Configuration(config_as_dict,
-                                      configdir=configuration.configdir,
-                                      filename=configuration.filename)
-
-        return configuration, DataContainer(datasets=datasets)
+        return new_configuration, DataContainer(datasets=datasets)
 
     def get_feature_names(self):
         """

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1950,37 +1950,18 @@ class FeaturePreprocessor:
                                                      standardize_features,
                                                      use_truncations)
 
-        new_config_dict = {'experiment_id': experiment_id,
-                           'subgroups': subgroups,
-                           'description': description,
-                           'train_file_location': train_file_location,
-                           'test_file_location': test_file_location,
-                           'model_name': model_name,
-                           'model_type': model_type,
-                           'train_label_column': train_label_column,
-                           'test_label_column': test_label_column,
-                           'id_column': id_column,
-                           'length_column': length_column,
-                           'second_human_score_column': second_human_score_column,
-                           'candidate_column': candidate_column,
-                           'subgroups': subgroups,
-                           'feature_subset_file': feature_subset_file,
-                           'trim_min': used_trim_min,
-                           'trim_max': used_trim_max,
-                           'trim_tolerance': spec_trim_tolerance,
-                           'use_scaled_predictions': use_scaled_predictions,
-                           'exclude_zero_scores': exclude_zero_scores,
-                           'exclude_listwise': exclude_listwise,
-                           'standardize_features': standardize_features,
-                           'min_items': min_items,
-                           'chosen_notebook_files': chosen_notebook_files}
+        # add internal configuration options that we need
+        new_config_obj = config_obj.copy()
+        internal_options_dict = {'chosen_notebook_files': chosen_notebook_files,
+                                 'exclude_listwise': exclude_listwise,
+                                 'model_name': model_name,
+                                 'model_type': model_type,
+                                 'test_file_location': test_file_location,
+                                 'train_file_location': train_file_location,
+                                 }
 
-        config_as_dict = config_obj.to_dict()
-        config_as_dict.update(new_config_dict)
-
-        new_config = Configuration(config_as_dict,
-                                   configdir=config_obj.configdir,
-                                   filename=config_obj.filename)
+        for key, value in internal_options_dict.items():
+            new_config_obj[key] = value
 
         new_container = [{'name': 'train_features',
                           'frame': df_train_features},
@@ -2005,7 +1986,7 @@ class FeaturePreprocessor:
 
         new_container = DataContainer(new_container)
 
-        return new_config, new_container
+        return new_config_obj, new_container
 
     def process_data_rsmeval(self, config_obj, data_container_obj):
         """

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1664,12 +1664,6 @@ class FeaturePreprocessor:
         if feature_subset_file is not None:
             feature_subset_file = DataReader.locate_files(feature_subset_file, configdir)
 
-        # get the experiment ID
-        experiment_id = config_obj['experiment_id']
-
-        # get the description
-        description = config_obj['description']
-
         # get the column name for the labels for the training and testing data
         train_label_column = config_obj['train_label_column']
         test_label_column = config_obj['test_label_column']

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1745,9 +1745,6 @@ class FeaturePreprocessor:
         use_fake_train_labels = train_label_column == 'fake'
         use_fake_test_labels = test_label_column == 'fake'
 
-        # are we analyzing scaled or raw prediction values
-        use_scaled_predictions = config_obj['use_scaled_predictions']
-
         # are we using truncations from the feature specs?
         use_truncations = config_obj['use_truncation_thresholds']
 
@@ -2020,12 +2017,6 @@ class FeaturePreprocessor:
 
         pred_file_location = DataReader.locate_files(config_obj['predictions_file'],
                                                      configpath)
-
-        # get the experiment ID
-        experiment_id = config_obj['experiment_id']
-
-        # get the description
-        description = config_obj['description']
 
         # get the column name for the labels for the training and testing data
         human_score_column = config_obj['human_score_column']
@@ -2301,24 +2292,15 @@ class FeaturePreprocessor:
 
         df_pred_other_columns = df_filtered_pred[other_columns]
 
-        new_config_dict = {'experiment_id': experiment_id,
-                           'subgroups': subgroups,
-                           'description': description,
-                           'pred_file_location': pred_file_location,
-                           'id_column': id_column,
-                           'second_human_score_column': second_human_score_column,
-                           'candidate_column': candidate_column,
-                           'use_scaled_predictions': use_scaled_predictions,
-                           'exclude_zero_scores': exclude_zero_scores,
-                           'exclude_listwise': exclude_listwise,
-                           'chosen_notebook_files': chosen_notebook_files}
+        # add internal configuration options that we need
+        new_config_obj = config_obj.copy()
+        internal_options_dict = {'pred_file_location': pred_file_location,
+                                 'exclude_listwise': exclude_listwise,
+                                 'use_scaled_predictions': use_scaled_predictions,
+                                 'chosen_notebook_files': chosen_notebook_files}
 
-        config_as_dict = config_obj.to_dict()
-        config_as_dict.update(new_config_dict)
-
-        new_config = Configuration(config_as_dict,
-                                   filename=config_obj.filename,
-                                   configdir=config_obj.configdir)
+        for key, value in internal_options_dict.items():
+            new_config_obj[key] = value
 
         # we need to make sure that `spkitemid` is the first column
         df_excluded = df_excluded[['spkitemid'] + [column for column in df_excluded
@@ -2343,7 +2325,7 @@ class FeaturePreprocessor:
 
         new_container = DataContainer(new_container)
 
-        return new_config, new_container
+        return new_config_obj, new_container
 
     def process_data_rsmpredict(self, config_obj, data_container_obj):
         """

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1947,15 +1947,18 @@ class FeaturePreprocessor:
                                                      standardize_features,
                                                      use_truncations)
 
-        # add internal configuration options that we need
+        # configuration options that either override previous values or are
+        # entirely for internal use
         new_config_obj = config_obj.copy()
         internal_options_dict = {'chosen_notebook_files': chosen_notebook_files,
                                  'exclude_listwise': exclude_listwise,
+                                 'feature_subset_file': feature_subset_file,
                                  'model_name': model_name,
                                  'model_type': model_type,
                                  'test_file_location': test_file_location,
                                  'train_file_location': train_file_location,
-                                 }
+                                 'trim_min': used_trim_min,
+                                 'trim_max': used_trim_max}
 
         for key, value in internal_options_dict.items():
             new_config_obj[key] = value

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -16,11 +16,9 @@ import numpy as np
 import pandas as pd
 
 from collections import defaultdict
-from os.path import dirname, abspath
 
 from numpy.random import RandomState
 
-from rsmtool.configuration_parser import Configuration
 from rsmtool.reader import DataReader
 from rsmtool.container import DataContainer
 from rsmtool.reporter import Reporter

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -626,8 +626,11 @@ class Reporter:
                      else config['min_items_per_candidate'])
 
         # determine minimum and maximum scores for trimming
-        min_score = config['trim_min'] - config['trim_tolerance']
-        max_score = config['trim_max'] + config['trim_tolerance']
+        (used_trim_min,
+         used_trim_max,
+         trim_tolerance) = config.get_trim_min_max_tolerance()
+        min_score = used_trim_min - trim_tolerance
+        max_score = used_trim_max + trim_tolerance
 
         environ_config = {'EXPERIMENT_ID': config['experiment_id'],
                           'DESCRIPTION': config['description'],

--- a/rsmtool/rsmcompare.py
+++ b/rsmtool/rsmcompare.py
@@ -23,7 +23,7 @@ from os.path import (abspath,
                      normpath)
 
 from rsmtool import VERSION_STRING
-from rsmtool.configuration_parser import ConfigurationParser, Configuration
+from rsmtool.configuration_parser import configure
 from rsmtool.reader import DataReader
 from rsmtool.reporter import Reporter
 from rsmtool.utils import LogFormatter
@@ -69,17 +69,16 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or Dictionary
-        Path to the experiment configuration file.
-        Users can also pass a `Configuration` object that is in memory
-        or a Python dictionary with keys corresponding to fields in the
-        configuration file.
-        Relative paths in the configuration file will be interpreted relative
-        to the location of the file. For configuration object
-        `.configdir` needs to be set to indicate the reference path. If
-        the user passes a dictionary, the reference path will be set to
-        the current directory and all relative paths will be resolved relative
-        to this path.
+    config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
+        Path to the experiment configuration file either a a string
+        or as a ``pathlib.Path`` object. Users can also pass a
+        ``Configuration`` object that is in memory or a Python dictionary
+        with keys corresponding to fields in the configuration file. Given a
+        configuration file, any relative paths in the configuration file
+        will be interpreted relative to the location of the file. Given a
+        ``Configuration`` object, relative paths will be interpreted
+        relative to the ``configdir`` attribute, that _must_ be set. Given
+        a dictionary, the reference path is set to the current directory.
     output_dir : str
         Path to the experiment output directory.
 
@@ -91,37 +90,7 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
 
     logger = logging.getLogger(__name__)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmcompare')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmcompare')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_comparison must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
+    configuration = configure('rsmcompare', config_file_or_obj_or_dict)
 
     logger.info('Saving configuration file.')
     configuration.save(output_dir)

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -180,7 +180,7 @@ def run_evaluation(config_file_or_obj_or_dict, output_dir):
 
     # generate the report
     logger.info('Starting report generation.')
-    reporter.create_report(processed_config,
+    reporter.create_report(pred_analysis_config,
                            csvdir,
                            figdir,
                            context='rsmeval')

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -26,7 +26,7 @@ from os.path import (basename,
                      split)
 
 from rsmtool import VERSION_STRING
-from rsmtool.configuration_parser import ConfigurationParser, Configuration
+from rsmtool.configuration_parser import configure
 from rsmtool.modeler import Modeler
 from rsmtool.preprocessor import FeaturePreprocessor
 from rsmtool.reader import DataReader
@@ -43,15 +43,16 @@ def compute_and_save_predictions(config_file_or_obj_or_dict,
 
     Parameters
     ----------
-    config_file_or_obj : str or configuration_parser.Configuration
-        Path to the experiment configuration file.
-        Users can also pass a `Configuration` object that is in memory.
-        Relative paths in the configuration file will be interpreted relative
-        to the location of the file. For configuration object
-        `.configdir` needs to be set to indicate the reference path. If
-        the user passes a dictionary, the reference path will be set to
-        the current directory and all relative paths will be resolved relative
-        to this path.
+    config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
+        Path to the experiment configuration file either a a string
+        or as a ``pathlib.Path`` object. Users can also pass a
+        ``Configuration`` object that is in memory or a Python dictionary
+        with keys corresponding to fields in the configuration file. Given a
+        configuration file, any relative paths in the configuration file
+        will be interpreted relative to the location of the file. Given a
+        ``Configuration`` object, relative paths will be interpreted
+        relative to the ``configdir`` attribute, that _must_ be set. Given
+        a dictionary, the reference path is set to the current directory.
     output_dir : str
         Path to the output directory for saving files.
     feats_file (optional): str
@@ -65,37 +66,7 @@ def compute_and_save_predictions(config_file_or_obj_or_dict,
 
     logger = logging.getLogger(__name__)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmpredict')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmpredict')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to compute_and_save_predictions must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
+    configuration = configure('rsmpredict', config_file_or_obj_or_dict)
 
     # get the experiment ID
     experiment_id = configuration['experiment_id']

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -19,13 +19,12 @@ import sys
 
 from os import listdir
 from os.path import (abspath,
-                     dirname,
                      exists,
                      join,
                      normpath)
 
 from rsmtool import VERSION_STRING
-from rsmtool.configuration_parser import ConfigurationParser, Configuration
+from rsmtool.configuration_parser import configure
 from rsmtool.reader import DataReader
 from rsmtool.reporter import Reporter
 
@@ -99,17 +98,16 @@ def run_summary(config_file_or_obj_or_dict,
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or dict
-        Path to the experiment configuration file.
-        Users can also pass a `Configuration` object that is in memory
-        or a Python dictionary with keys corresponding to fields in the
-        configuration file.
-        Relative paths in the configuration file will be interpreted relative
-        to the location of the file. For configuration object
-        `.configdir` needs to be set to indicate the reference path. If
-        the user passes a dictionary, the reference path will be set
-        to the current directory and all relative paths will be resolved
-        relative to this path.
+    config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
+        Path to the experiment configuration file either a a string
+        or as a ``pathlib.Path`` object. Users can also pass a
+        ``Configuration`` object that is in memory or a Python dictionary
+        with keys corresponding to fields in the configuration file. Given a
+        configuration file, any relative paths in the configuration file
+        will be interpreted relative to the location of the file. Given a
+        ``Configuration`` object, relative paths will be interpreted
+        relative to the ``configdir`` attribute, that _must_ be set. Given
+        a dictionary, the reference path is set to the current directory.
     output_dir : str
         Path to the experiment output directory.
 
@@ -131,37 +129,8 @@ def run_summary(config_file_or_obj_or_dict,
     os.makedirs(figdir, exist_ok=True)
     os.makedirs(reportdir, exist_ok=True)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
+    configuration = configure('rsmsummarize', config_file_or_obj_or_dict)
 
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict,
-                                                                          context='rsmsummarize')
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict,
-                                                                            context='rsmsummarize')
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_summary must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
     logger.info('Saving configuration file.')
     configuration.save(output_dir)
 

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -15,11 +15,11 @@ import logging
 import sys
 
 from os import listdir, getcwd, makedirs
-from os.path import abspath, exists, join, dirname
+from os.path import abspath, exists, join
 
 from rsmtool import VERSION_STRING
 from rsmtool.analyzer import Analyzer
-from rsmtool.configuration_parser import ConfigurationParser, Configuration
+from rsmtool.configuration_parser import configure
 from rsmtool.modeler import Modeler
 from rsmtool.preprocessor import FeaturePreprocessor
 from rsmtool.reader import DataReader
@@ -31,23 +31,21 @@ from rsmtool.writer import DataWriter
 def run_experiment(config_file_or_obj_or_dict,
                    output_dir):
     """
-    Run RSMTool experiment using the given configuration
+    Run an ``rsmtool`` experiment using the given configuration
     file and generate all outputs in the given directory.
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : str or Configuration or Dictionary
-        Path to the experiment configuration file.
-        Users can also pass a `Configuration` object that is in memory
-        or a Python dictionary with keys corresponding to fields in the
-        configuration file.
-        Relative paths in the configuration file will be interpreted relative
-        to the location of the file. For configuration object
-        `.configdir` needs to be set to indicate the reference path. If
-        the user passes a dictionary, the reference path will be set to
-        the current directory and all relative paths will be resolved relative
-        to this path.
-        to the current directory.
+    config_file_or_obj_or_dict : str or pathlib.Path or dict or Configuration
+        Path to the experiment configuration file either a a string
+        or as a ``pathlib.Path`` object. Users can also pass a
+        ``Configuration`` object that is in memory or a Python dictionary
+        with keys corresponding to fields in the configuration file. Given a
+        configuration file, any relative paths in the configuration file
+        will be interpreted relative to the location of the file. Given a
+        ``Configuration`` object, relative paths will be interpreted
+        relative to the ``configdir`` attribute, that _must_ be set. Given
+        a dictionary, the reference path is set to the current directory.
     output_dir : str
         Path to the experiment output directory.
 
@@ -74,35 +72,7 @@ def run_experiment(config_file_or_obj_or_dict,
     makedirs(figdir, exist_ok=True)
     makedirs(reportdir, exist_ok=True)
 
-    # check what sort of input we got
-    # if we got a string we consider this to be path to config file
-    if isinstance(config_file_or_obj_or_dict, str):
-
-        # Instantiate configuration parser object
-        parser = ConfigurationParser.get_configparser(config_file_or_obj_or_dict)
-        configuration = parser.read_normalize_validate_and_process_config(config_file_or_obj_or_dict)
-
-    elif isinstance(config_file_or_obj_or_dict, dict):
-
-        # initialize the parser from dict
-        parser = ConfigurationParser()
-        configuration = parser.load_normalize_and_validate_config_from_dict(config_file_or_obj_or_dict)
-
-    elif isinstance(config_file_or_obj_or_dict, Configuration):
-
-        configuration = config_file_or_obj_or_dict
-        # raise an error if we are passed a Configuration object
-        # without a configdir attribute. This can only
-        # happen if the object was constructed using an earlier version
-        # of RSMTool and stored
-        if configuration.configdir is None:
-            raise AttributeError("Configuration object must have configdir attribute.")
-
-    else:
-        raise ValueError("The input to run_experiment must be "
-                         "a path to the file (str), a dictionary, "
-                         "or a configuration object. You passed "
-                         "{}.".format(type(config_file_or_obj_or_dict)))
+    configuration = configure('rsmtool', config_file_or_obj_or_dict)
 
     logger.info('Saving configuration file.')
     configuration.save(output_dir)

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -277,7 +277,7 @@ def run_experiment(config_file_or_obj_or_dict,
 
     # generate the report
     logger.info('Starting report generation.')
-    reporter.create_report(processed_config,
+    reporter.create_report(pred_analysis_config,
                            csvdir,
                            figdir)
 

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -308,16 +308,19 @@ def convert_to_float(value):
     return int_to_float(string_to_number(value))
 
 
-def parse_json_with_comments(filename):
+def parse_json_with_comments(pathlike):
     """
     Parse a JSON file after removing any comments.
+
     Comments can use either ``//`` for single-line
     comments or or ``/* ... */`` for multi-line comments.
+    The input filepath can be a string or ``pathlib.Path``.
 
     Parameters
     ----------
-    filename : str
-        Path to the input JSON file.
+    filename : str or os.PathLike
+        Path to the input JSON file either as a string
+        or as a ``pathlib.Path`` object.
 
     Returns
     -------
@@ -334,7 +337,11 @@ def parse_json_with_comments(filename):
     comment_re = re.compile(r'(^)?[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
                             re.DOTALL | re.MULTILINE)
 
-    with open(filename) as file_buff:
+    # if we passed in a string, convert it to a Path
+    if isinstance(pathlike, str):
+        pathlike = Path(pathlike)
+
+    with open(pathlike, 'r') as file_buff:
         content = ''.join(file_buff.readlines())
 
         # Looking for comments

--- a/rsmtool/utils.py
+++ b/rsmtool/utils.py
@@ -16,9 +16,9 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from math import ceil
 from glob import glob
 from importlib import import_module
+from math import ceil
 from os.path import exists, isabs, join, relpath
 from pathlib import Path
 from string import Template
@@ -73,7 +73,6 @@ DEFAULTS = {'id_column': 'spkitemid',
             'custom_sections': None,
             'feature_subset_file': None,
             'feature_subset': None,
-            'feature_prefix': None,
             'trim_min': None,
             'trim_max': None,
             'trim_tolerance': 0.4998,
@@ -86,8 +85,7 @@ DEFAULTS = {'id_column': 'spkitemid',
             'min_items_per_candidate': None,
             'experiment_names': None}
 
-LIST_FIELDS = ['feature_prefix',
-               'general_sections',
+LIST_FIELDS = ['general_sections',
                'special_sections',
                'custom_sections',
                'subgroups',

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -8,7 +8,7 @@ import pandas as pd
 from io import StringIO
 from os import getcwd
 from os.path import abspath, dirname, join
-
+from pathlib import Path
 from shutil import rmtree
 
 from numpy.testing import assert_array_equal
@@ -92,7 +92,7 @@ class TestConfigurationParser:
                 "flag_column": "abc",
                 "model": 'LinearRegression'}
 
-        configdir = abspath('/path/to/configdir')
+        configdir = Path('/path/to/configdir').resolve()
         configuration = Configuration(data, configdir=configdir)
         eq_(configuration._configdir, configdir)
 
@@ -103,7 +103,7 @@ class TestConfigurationParser:
                 "flag_column": "abc",
                 "model": 'LinearRegression'}
 
-        configdir = getcwd()
+        configdir = Path(getcwd())
         configuration = Configuration(data)
         eq_(configuration._configdir, configdir)
 
@@ -513,7 +513,7 @@ class TestConfiguration:
 
             config = Configuration(config_dict, filepath)
             eq_(config._filename, 'file.json')
-            eq_(config._configdir, abspath('some/path'))
+            eq_(config._configdir, Path('some/path').resolve())
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
 
@@ -526,7 +526,7 @@ class TestConfiguration:
 
         config = Configuration(config_dict, filename=filename)
         eq_(config._filename, filename)
-        eq_(config.configdir, abspath(getcwd()))
+        eq_(config.configdir, getcwd())
 
     def test_init_with_filename_and_configdir_as_kword_argument(self):
         filename = 'file.json'
@@ -540,7 +540,7 @@ class TestConfiguration:
                                filename=filename,
                                configdir=configdir)
         eq_(config._filename, filename)
-        eq_(config._configdir, abspath(configdir))
+        eq_(config._configdir, Path(configdir).resolve())
 
     def test_init_with_configdir_only_as_kword_argument(self):
         configdir = 'some/path'
@@ -552,7 +552,7 @@ class TestConfiguration:
         config = Configuration(config_dict,
                                configdir=configdir)
         eq_(config._filename, None)
-        eq_(config._configdir, abspath(configdir))
+        eq_(config._configdir, Path(configdir).resolve())
 
     @ raises(ValueError)
     def test_init_with_filepath_positional_and_filename_keyword(self):

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -894,6 +894,22 @@ class TestConfiguration:
             assert len(warning_list) == 1  # we get one deprecation warning here
             assert issubclass(warning_list[0].category, DeprecationWarning)
 
+    # make sure that accessing filepath attribute when filename
+    # is not defined raises an exception
+    @raises(AttributeError)
+    def test_get_filepath_no_filename(self):
+        with warnings.catch_warnings():
+            config = Configuration({"experiment_id": '001',
+                                    "train_file": "/foo/train.csv",
+                                    "test_file": "/foo/test.csv",
+                                    "trim_min": 1,
+                                    "trim_max": 6,
+                                    "flag_column": "[advisories]",
+                                    "model": 'LinearRegression'},
+                                   configdir='/path/to')
+
+            _ = config.filepath
+
     # this is a test for an attribute that will be
     # deprecated
     def test_set_filepath(self):

--- a/tests/test_configuration_parser.py
+++ b/tests/test_configuration_parser.py
@@ -24,9 +24,7 @@ from nose.tools import (assert_equal,
 from rsmtool.convert_feature_json import convert_feature_json_file
 
 from rsmtool.configuration_parser import (Configuration,
-                                          ConfigurationParser,
-                                          CFGConfigurationParser,
-                                          JSONConfigurationParser)
+                                          ConfigurationParser)
 
 
 _MY_DIR = dirname(__file__)
@@ -35,7 +33,7 @@ _MY_DIR = dirname(__file__)
 class TestConfigurationParser:
 
     def setUp(self):
-        self.parser = ConfigurationParser()
+        pass
 
     def test_normalize_config(self):
         data = {'expID': 'experiment_1',
@@ -53,10 +51,7 @@ class TestConfigurationParser:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=DeprecationWarning)
 
-            # Add data to `ConfigurationParser` object
-            self.parser.load_config_from_dict(data)
-
-            newdata = self.parser.normalize_config()
+            newdata = ConfigurationParser.normalize_config(data)
             ok_('experiment_id' in newdata.keys())
             assert_equal(newdata['experiment_id'], 'experiment_1')
             assert_equal(newdata['use_scaled_predictions'], True)
@@ -68,11 +63,8 @@ class TestConfigurationParser:
                 'scale': 'Yes'}
         with warnings.catch_warnings():
 
-            # Add data to `ConfigurationParser` object
-            self.parser._config = data
-
             warnings.filterwarnings('ignore', category=DeprecationWarning)
-            assert_raises(ValueError, self.parser.normalize_config)
+            assert_raises(ValueError, ConfigurationParser.normalize_config, data)
 
         # test when no scaling is specified
         data = {'expID': 'experiment_1',
@@ -90,46 +82,45 @@ class TestConfigurationParser:
             warnings.filterwarnings('ignore', category=DeprecationWarning)
 
             # Add data to `ConfigurationParser` object
-            self.parser._config = data
-            newdata = self.parser.normalize_config()
+            newdata = ConfigurationParser.normalize_config(data)
             ok_('use_scaled_predictions' not in newdata.keys())
 
     def test_load_config_from_dict(self):
-        data = {'expID': 'test'}
-        configdir = abspath('/path/to/configdir')
-        self.parser.load_config_from_dict(data,
-                                          configdir=configdir)
-        eq_(self.parser._configdir, configdir)
+        data = {'expID': '001',
+                'train_file': 'path/to/train.tsv',
+                'test_file': 'path/to/test.tsv',
+                "flag_column": "abc",
+                "model": 'LinearRegression'}
 
+        configdir = abspath('/path/to/configdir')
+        configuration = Configuration(data, configdir=configdir)
+        eq_(configuration._configdir, configdir)
 
     def test_load_config_from_dict_no_configdir(self):
-        data = {'expID': 'test'}
+        data = {'expID': 'test',
+                'train_file': 'path/to/train.tsv',
+                'test_file': 'path/to/test.tsv',
+                "flag_column": "abc",
+                "model": 'LinearRegression'}
+
         configdir = getcwd()
-        self.parser.load_config_from_dict(data)
-        eq_(self.parser._configdir, configdir)
-
-
-    @raises(AttributeError)
-    def test_load_config_from_dict_dict_already_assigned(self):
-        data = {'expID': 'test'}
-        configdir = 'some/config/dir'
-        self.parser._config = data
-        self.parser.load_config_from_dict(data, configdir)
+        configuration = Configuration(data)
+        eq_(configuration._configdir, configdir)
 
     @raises(TypeError)
     def test_load_config_from_dict_wrong_type(self):
         data = [('expID', 'test')]
         configdir = 'some/config/dir'
-        self.parser.load_config_from_dict(data, configdir)
+        Configuration(data, configdir)
 
-    def test_load_and_normalize_config_from_dict_rsmtool(self):
+    def test_parse_config_from_dict_rsmtool(self):
         data = {'experiment_id': 'experiment_1',
                 'train_file': 'data/rsmtool_smTrain.csv',
                 'test_file': 'data/rsmtool_smEval.csv',
                 'model': 'LinearRegression'}
 
-        # Add data to `ConfigurationParser` object
-        newdata = self.parser.load_normalize_and_validate_config_from_dict(data)
+        # Add data to `Configuration` object
+        newdata = Configuration(data)
         assert_equal(newdata['id_column'], 'spkitemid')
         assert_equal(newdata['use_scaled_predictions'], False)
         assert_equal(newdata['select_transformations'], False)
@@ -137,30 +128,25 @@ class TestConfigurationParser:
         assert_equal(newdata['description'], '')
         assert_equal(newdata.configdir, getcwd())
 
-
-    def test_load_and_normalize_config_from_dict_rsmeval(self):
+    def test_parse_config_from_dict_rsmeval(self):
         data = {'experiment_id': 'experiment_1',
                 'predictions_file': 'data/rsmtool_smTrain.csv',
                 'system_score_column': 'system',
                 'trim_min': 1,
                 'trim_max': 5}
 
-        # Add data to `ConfigurationParser` object
-        newdata = self.parser.load_normalize_and_validate_config_from_dict(data,
-                                                                         context='rsmeval')
+        # Add data to `Configuration` object
+        newdata = Configuration(data, context='rsmeval')
         assert_equal(newdata['id_column'], 'spkitemid')
         assert_array_equal(newdata['general_sections'], ['all'])
         assert_equal(newdata['description'], '')
         assert_equal(newdata.configdir, getcwd())
 
-
     @raises(ValueError)
     def test_validate_config_missing_fields(self):
         data = {'expID': 'test'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_min_responses_but_no_candidate(self):
@@ -170,9 +156,7 @@ class TestConfigurationParser:
                 'model': 'LinearRegression',
                 'min_responses_per_candidate': 5}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     def test_validate_config_unspecified_fields(self):
         data = {'experiment_id': 'experiment_1',
@@ -180,9 +164,7 @@ class TestConfigurationParser:
                 'test_file': 'data/rsmtool_smEval.csv',
                 'model': 'LinearRegression'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser._config = data
-        newdata = self.parser.validate_config()
+        newdata = ConfigurationParser.validate_config(data)
         assert_equal(newdata['id_column'], 'spkitemid')
         assert_equal(newdata['use_scaled_predictions'], False)
         assert_equal(newdata['select_transformations'], False)
@@ -198,9 +180,7 @@ class TestConfigurationParser:
                 'model': 'LinearRegression',
                 'output': 'foobar'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_experiment_id_1(self):
@@ -209,9 +189,7 @@ class TestConfigurationParser:
                 'test_file': 'data/rsmtool_smEval.csv',
                 'model': 'LinearRegression'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_experiment_id_2(self):
@@ -221,9 +199,7 @@ class TestConfigurationParser:
                 'trim_min': 1,
                 'trim_max': 5}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmeval')
+        _ = ConfigurationParser.validate_config(data, context='rsmeval')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_3(self):
@@ -233,9 +209,7 @@ class TestConfigurationParser:
                 'experiment_id_new': 'new_experiment',
                 'experiment_dir_new': 'data/new'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmcompare')
+        _ = ConfigurationParser.validate_config(data, context='rsmcompare')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_4(self):
@@ -245,9 +219,7 @@ class TestConfigurationParser:
                 'experiment_id_new': 'new_experiment',
                 'experiment_dir_new': 'data/new'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmcompare')
+        _ = ConfigurationParser.validate_config(data, context='rsmcompare')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_5(self):
@@ -260,9 +232,7 @@ class TestConfigurationParser:
                 'test_file': 'data/rsmtool_smEval.csv',
                 'model': 'LinearRegression'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_experiment_id_6(self):
@@ -276,9 +246,7 @@ class TestConfigurationParser:
                 'trim_min': 1,
                 'trim_max': 5}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmeval')
+        _ = ConfigurationParser.validate_config(data, context='rsmeval')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_7(self):
@@ -292,18 +260,14 @@ class TestConfigurationParser:
                 'experiment_id_new': 'new_experiment',
                 'experiment_dir_new': 'data/new'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmcompare')
+        _ = ConfigurationParser.validate_config(data, context='rsmcompare')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_8(self):
         data = {'summary_id': 'model summary',
                 'experiment_dirs': []}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmsummarize')
+        _ = ConfigurationParser.validate_config(data, context='rsmsummarize')
 
     @raises(ValueError)
     def test_validate_config_experiment_id_9(self):
@@ -314,9 +278,7 @@ class TestConfigurationParser:
                 'really_really_really_long_id',
                 'experiment_dirs': []}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmsummarize')
+        _ = ConfigurationParser.validate_config(data, context='rsmsummarize')
 
     @raises(ValueError)
     def test_validate_config_too_many_experiment_names(self):
@@ -324,9 +286,7 @@ class TestConfigurationParser:
                 'experiment_dirs': ["dir1", "dir2", "dir3"],
                 'experiment_names': ['exp1', 'exp2', 'exp3', 'exp4']}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmsummarize')
+        _ = ConfigurationParser.validate_config(data, context='rsmsummarize')
 
     @raises(ValueError)
     def test_validate_config_too_few_experiment_names(self):
@@ -334,9 +294,7 @@ class TestConfigurationParser:
                 'experiment_dirs': ["dir1", "dir2", "dir3"],
                 'experiment_names': ['exp1', 'exp2']}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config(context='rsmsummarize')
+        _ = ConfigurationParser.validate_config(data, context='rsmsummarize')
 
     def test_validate_config_numeric_subgroup_threshold(self):
         data = {'experiment_id': 'experiment_1',
@@ -345,8 +303,8 @@ class TestConfigurationParser:
                 'model': 'LinearRegression',
                 'subgroups': ['L2', 'L1'],
                 'min_n_per_group': 100}
-        self.parser._config = data
-        newdata = self.parser.validate_config()
+
+        newdata = ConfigurationParser.validate_config(data)
         eq_(type(newdata['min_n_per_group']), dict)
         assert_equal(newdata['min_n_per_group']['L1'], 100)
         assert_equal(newdata['min_n_per_group']['L2'], 100)
@@ -359,8 +317,8 @@ class TestConfigurationParser:
                 'subgroups': ['L2', 'L1'],
                 'min_n_per_group': {"L1": 100,
                                     "L2": 200}}
-        self.parser._config = data
-        newdata = self.parser.validate_config()
+
+        newdata = ConfigurationParser.validate_config(data)
         eq_(type(newdata['min_n_per_group']), dict)
         assert_equal(newdata['min_n_per_group']['L1'], 100)
         assert_equal(newdata['min_n_per_group']['L2'], 200)
@@ -373,8 +331,8 @@ class TestConfigurationParser:
                 'model': 'LinearRegression',
                 'subgroups': ['L1', 'L2'],
                 'min_n_per_group': {"L1": 100}}
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_valdiate_config_too_many_subgroup_keys(self):
@@ -386,8 +344,8 @@ class TestConfigurationParser:
                 'min_n_per_group': {"L1": 100,
                                     "L2": 100,
                                     "L4": 50}}
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_mismatched_subgroup_keys(self):
@@ -398,8 +356,8 @@ class TestConfigurationParser:
                 'subgroups': ['L1', 'L2'],
                 'min_n_per_group': {"L1": 100,
                                     "L4": 50}}
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_validate_config_min_n_without_subgroups(self):
@@ -409,8 +367,8 @@ class TestConfigurationParser:
                 'model': 'LinearRegression',
                 'min_n_per_group': {"L1": 100,
                                     "L2": 50}}
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+
+        _ = ConfigurationParser.validate_config(data)
 
     def test_process_fields(self):
         data = {'experiment_id': 'experiment_1',
@@ -419,18 +377,10 @@ class TestConfigurationParser:
                 'description': 'Test',
                 'model': 'empWt',
                 'use_scaled_predictions': 'True',
-                'feature_prefix': '1gram, 2gram',
                 'subgroups': 'native language, GPA_range',
                 'exclude_zero_scores': 'false'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.validate_config(inplace=False)
-
-        # Add data to `ConfigurationParser` object
-        self.parser._config = newdata
-        newdata = self.parser.process_config(inplace=False)
-        assert_array_equal(newdata['feature_prefix'], ['1gram', '2gram'])
+        newdata = ConfigurationParser.process_config(data)
         assert_array_equal(newdata['subgroups'], ['native language', 'GPA_range'])
         eq_(type(newdata['use_scaled_predictions']), bool)
         eq_(newdata['use_scaled_predictions'], True)
@@ -448,12 +398,7 @@ class TestConfigurationParser:
                 'subgroups': 'native language, GPA_range',
                 'exclude_zero_scores': 'Yes'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.validate_config()
-        # Add data to `ConfigurationParser` object
-        self.parser._config = newdata
-        newdata = self.parser.process_config()
+        _ = ConfigurationParser.process_config(data)
 
     @raises(ValueError)
     def test_process_fields_with_integer(self):
@@ -467,21 +412,14 @@ class TestConfigurationParser:
                 'subgroups': 'native language, GPA_range',
                 'exclude_zero_scores': 1}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.validate_config()
-        # Add data to `ConfigurationParser` object
-        self.parser._config = newdata
-        newdata = self.parser.process_config()
+        _ = ConfigurationParser.process_config(data)
 
     def test_process_fields_rsmsummarize(self):
         data = {'summary_id': 'summary',
                 'experiment_dirs': 'home/dir1, home/dir2, home/dir3',
                 'experiment_names': 'exp1, exp2, exp3'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.process_config(inplace=False)
+        newdata = ConfigurationParser.process_config(data)
 
         assert_array_equal(newdata['experiment_dirs'], ['home/dir1',
                                                         'home/dir2',
@@ -499,9 +437,7 @@ class TestConfigurationParser:
                 'model': 'LinearSVR',
                 'skll_objective': 'squared_error'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_wrong_skll_model_for_expected_scores(self):
@@ -512,9 +448,7 @@ class TestConfigurationParser:
                 'model': 'LinearSVR',
                 'predict_expected_scores': 'true'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
     @raises(ValueError)
     def test_builtin_model_for_expected_scores(self):
@@ -525,11 +459,9 @@ class TestConfigurationParser:
                 'model': 'NNLR',
                 'predict_expected_scores': 'true'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        self.parser.validate_config()
+        _ = ConfigurationParser.validate_config(data)
 
-    def test_proces_validate_correct_order_boolean(self):
+    def test_process_validate_correct_order_boolean(self):
         data = {'experiment_id': 'experiment_1',
                 'train_file': 'data/rsmtool_smTrain.csv',
                 'test_file': 'data/rsmtool_smEval.csv',
@@ -537,10 +469,8 @@ class TestConfigurationParser:
                 'model': 'NNLR',
                 'predict_expected_scores': 'false'}
 
-        # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.normalize_validate_and_process_config()
-        eq_(newdata['predict_expected_scores'], False)
+        configuration = Configuration(data)
+        eq_(configuration['predict_expected_scores'], False)
 
     def test_process_validate_correct_order_list(self):
         data = {'summary_id': 'summary',
@@ -548,38 +478,39 @@ class TestConfigurationParser:
                 'experiment_names': 'exp1, exp2, exp3'}
 
         # Add data to `ConfigurationParser` object
-        self.parser.load_config_from_dict(data)
-        newdata = self.parser.normalize_validate_and_process_config(context='rsmsummarize')
-
-        assert_array_equal(newdata['experiment_dirs'], ['home/dir1',
-                                                        'home/dir2',
-                                                        'home/dir3'])
-        assert_array_equal(newdata['experiment_names'], ['exp1',
-                                                         'exp2',
-                                                         'exp3'])
-
-    def test_get_correct_configparser_cfg(self):
-        config_parser = ConfigurationParser.get_configparser('config.cfg')
-        assert isinstance(config_parser, CFGConfigurationParser)
-
-    def test_get_correct_configparser_json(self):
-        config_parser = ConfigurationParser.get_configparser('config.json')
-        assert isinstance(config_parser, JSONConfigurationParser)
+        configuration = Configuration(data, context='rsmsummarize')
+        assert_array_equal(configuration['experiment_dirs'], ['home/dir1',
+                                                              'home/dir2',
+                                                              'home/dir3'])
+        assert_array_equal(configuration['experiment_names'],
+                           ['exp1', 'exp2', 'exp3'])
 
 
 class TestConfiguration:
 
     def test_init_default_values(self):
-        config_dict = {'exp_id': 'my_experiment'}
+        config_dict = {"expID": 'my_experiment',
+                       "train_file": 'path/to/train.tsv',
+                       "test_file": 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
+
         config = Configuration(config_dict)
-        eq_(config._config, config_dict)
+        for key in config_dict:
+            if key == 'expID':
+                continue
+            eq_(config._config[key], config_dict[key])
+        eq_(config._config['experiment_id'], config_dict['expID'])
         eq_(config._filename, None)
         eq_(config.configdir, abspath(getcwd()))
 
     def test_init_with_filepath_as_positional_argument(self):
         with warnings.catch_warnings(record=True) as w:
             filepath = 'some/path/file.json'
-            config_dict = {'exp_id': 'my_experiment'}
+            config_dict = {'experiment_id': 'my_experiment',
+                           'train_file': 'path/to/train.tsv',
+                           'test_file': 'path/to/test.tsv',
+                           "model": 'LinearRegression'}
+
             config = Configuration(config_dict, filepath)
             eq_(config._filename, 'file.json')
             eq_(config._configdir, abspath('some/path'))
@@ -588,7 +519,11 @@ class TestConfiguration:
 
     def test_init_with_filename_as_kword_argument(self):
         filename = 'file.json'
-        config_dict = {'exp_id': 'my_experiment'}
+        config_dict = {'experiment_id': 'my_experiment',
+                       'train_file': 'path/to/train.tsv',
+                       'test_file': 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
+
         config = Configuration(config_dict, filename=filename)
         eq_(config._filename, filename)
         eq_(config.configdir, abspath(getcwd()))
@@ -596,17 +531,24 @@ class TestConfiguration:
     def test_init_with_filename_and_configdir_as_kword_argument(self):
         filename = 'file.json'
         configdir = 'some/path'
-        config_dict = {'exp_id': 'my_experiment'}
+        config_dict = {'experiment_id': 'my_experiment',
+                       'train_file': 'path/to/train.tsv',
+                       'test_file': 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
+
         config = Configuration(config_dict,
                                filename=filename,
                                configdir=configdir)
         eq_(config._filename, filename)
         eq_(config._configdir, abspath(configdir))
 
-
     def test_init_with_configdir_only_as_kword_argument(self):
         configdir = 'some/path'
-        config_dict = {'exp_id': 'my_experiment'}
+        config_dict = {'experiment_id': 'my_experiment',
+                       'train_file': 'path/to/train.tsv',
+                       'test_file': 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
+
         config = Configuration(config_dict,
                                configdir=configdir)
         eq_(config._filename, None)
@@ -615,7 +557,11 @@ class TestConfiguration:
     @ raises(ValueError)
     def test_init_with_filepath_positional_and_filename_keyword(self):
         filepath = 'some/path/file.json'
-        config_dict = {'exp_id': 'my_experiment'}
+        config_dict = {'experiment_id': 'my_experiment',
+                       'train_file': 'path/to/train.tsv',
+                       'test_file': 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
+
         _ = Configuration(config_dict,
                           filepath,
                           filename=filepath)
@@ -624,11 +570,14 @@ class TestConfiguration:
     def test_init_with_filepath_positional_and_configdir_keyword(self):
         filepath = 'some/path/file.json'
         configdir = 'some/path'
-        config_dict = {'exp_id': 'my_experiment'}
+
+        config_dict = {'experiment_id': 'my_experiment',
+                       'train_file': 'path/to/train.tsv',
+                       'test_file': 'path/to/test.tsv',
+                       "model": 'LinearRegression'}
         _ = Configuration(config_dict,
                           filepath,
                           configdir=configdir)
-
 
     def check_logging_output(self, expected, function, *args, **kwargs):
 
@@ -658,73 +607,119 @@ class TestConfiguration:
         return result
 
     def test_pop_value(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        dictionary = {'experiment_id': '001',
+                      'train_file': 'path/to/train.tsv',
+                      'test_file': 'path/to/test.tsv',
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         value = config.pop("experiment_id")
         eq_(value, '001')
 
     def test_pop_value_default(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        dictionary = {'experiment_id': '001',
+                      'train_file': 'path/to/train.tsv',
+                      'test_file': 'path/to/test.tsv',
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         value = config.pop("foo", "bar")
         eq_(value, 'bar')
 
     def test_copy(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6,
-                      "object": [1, 2, 3]}
-        config = Configuration(dictionary)
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": [1, 2, 3],
+                                "model": 'LinearRegression'})
+
         config_copy = config.copy()
         assert_not_equal(id(config), id(config_copy))
         for key in config.keys():
 
             # check to make sure this is a deep copy
-            if key == "object":
+            if key == "flag_column":
                 assert_not_equal(id(config[key]), id(config_copy[key]))
             assert_equal(config[key], config_copy[key])
 
     def test_copy_not_deep(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6,
-                      "object": [1, 2, 3]}
-        config = Configuration(dictionary)
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": [1, 2, 3],
+                                "model": 'LinearRegression'})
+
         config_copy = config.copy(deep=False)
         assert_not_equal(id(config), id(config_copy))
         for key in config.keys():
 
             # check to make sure this is a shallow copy
-            if key == "object":
+            if key == "flag_column":
                 assert_equal(id(config[key]), id(config_copy[key]))
             assert_equal(config[key], config_copy[key])
 
     def test_check_flag_column(self):
         input_dict = {"advisory flag": ['0']}
-        config = Configuration({"flag_column": input_dict})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": input_dict,
+                                "model": 'LinearRegression'})
+
         output_dict = config.check_flag_column()
         eq_(input_dict, output_dict)
 
     def test_check_flag_column_flag_column_test(self):
         input_dict = {"advisory flag": ['0']}
-        config = Configuration({"flag_column_test": input_dict})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column_test": input_dict,
+                                "flag_column": input_dict,
+                                "model": 'LinearRegression'})
+
         output_dict = config.check_flag_column("flag_column_test")
         eq_(input_dict, output_dict)
 
     def test_check_flag_column_keep_numeric(self):
         input_dict = {"advisory flag": [1, 2, 3]}
-        config = Configuration({"flag_column": input_dict})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": input_dict,
+                                "model": 'LinearRegression'})
+
         output_dict = config.check_flag_column()
         eq_(output_dict, {"advisory flag": [1, 2, 3]})
 
     def test_check_flag_column_no_values(self):
-        config = Configuration({"flag_column": None})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": None,
+                                "model": 'LinearRegression'})
+
         flag_dict = config.check_flag_column()
         eq_(flag_dict, {})
 
     def test_check_flag_column_convert_to_list(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
+
         flag_dict = config.check_flag_column()
         eq_(flag_dict, {"advisories": ['0']})
 
     def test_check_flag_column_convert_to_list_test(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
 
         flag_dict = self.check_logging_output('evaluating',
                                               config.check_flag_column,
@@ -732,21 +727,36 @@ class TestConfiguration:
         eq_(flag_dict, {"advisories": ['0']})
 
     def test_check_flag_column_convert_to_list_train(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
+
         flag_dict = self.check_logging_output('training',
                                               config.check_flag_column,
                                               partition='train')
         eq_(flag_dict, {"advisories": ['0']})
 
     def test_check_flag_column_convert_to_list_both(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
+
         flag_dict = self.check_logging_output('training and evaluating',
                                               config.check_flag_column,
                                               partition='both')
         eq_(flag_dict, {"advisories": ['0']})
 
     def test_check_flag_column_convert_to_list_unknown(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
+
         flag_dict = self.check_logging_output('training and/or evaluating',
                                               config.check_flag_column,
                                               partition='unknown')
@@ -754,90 +764,151 @@ class TestConfiguration:
 
     @raises(AssertionError)
     def test_check_flag_column_convert_to_list_test_error(self):
-        config = Configuration({"flag_column": {"advisories": "0"}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": "0"},
+                                "model": 'LinearRegression'})
+
         self.check_logging_output('training',
                                   config.check_flag_column,
                                   partition='test')
 
     def test_check_flag_column_convert_to_list_keep_numeric(self):
-        config = Configuration({"flag_column": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         flag_dict = config.check_flag_column()
         eq_(flag_dict, {"advisories": [123]})
 
     def test_contains_key(self):
-        config = Configuration({"flag_column": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         ok_('flag_column' in config, msg="Test 'flag_column' in config.")
 
     def test_does_not_contain_nested_key(self):
-        config = Configuration({"flag_column": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         eq_('advisories' in config, False)
 
     def test_get_item(self):
         expected_item = {"advisories": 123}
-        config = Configuration({"flag_column": expected_item})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": expected_item,
+                                "model": 'LinearRegression'})
+
         item = config['flag_column']
         eq_(item, expected_item)
 
     def test_set_item(self):
         expected_item = ["45", 34]
-        config = Configuration({"flag_column": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         config['other_column'] = expected_item
         eq_(config['other_column'], expected_item)
 
-    def test_check_len(self):
-        expected_len = 2
-        config = Configuration({"flag_column": {"advisories": 123}, 'other_column': 5})
-        eq_(len(config), expected_len)
-
     @raises(ValueError)
     def test_check_flag_column_wrong_format(self):
-        config = Configuration({"flag_column": "[advisories]"})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'})
+
         config.check_flag_column()
 
     @raises(ValueError)
     def test_check_flag_column_wrong_partition(self):
-        config = Configuration({"flag_column_test": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column_test": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         config.check_flag_column(partition='eval')
 
     @raises(ValueError)
     def test_check_flag_column_mismatched_partition(self):
-        config = Configuration({"flag_column_test": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column_test": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         config.check_flag_column(flag_column='flag_column_test',
                                  partition='train')
 
     @raises(ValueError)
     def test_check_flag_column_mismatched_partition_both(self):
-        config = Configuration({"flag_column_test": {"advisories": 123}})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column_test": {"advisories": 123},
+                                "model": 'LinearRegression'})
+
         config.check_flag_column(flag_column='flag_column_test',
                                  partition='both')
 
     def test_str_correct(self):
-        config_dict = {'flag_column': '[advisories]'}
-        config = Configuration(config_dict)
-        print(config)
-        eq_(config.__str__(), 'flag_column')
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'})
+
+        eq_(config['flag_column'], '[advisories]')
 
     # this is a test for an attribute that will be
     # deprecated
     def test_get_filepath(self):
         with warnings.catch_warnings(record=True) as warning_list:
             filepath = '/path/to/file.json'
-            config = Configuration({"flag_column": "[advisories]"},
-                                   configdir='/path/to/',
-                                   filename='file.json')
+            config = Configuration({"experiment_id": '001',
+                                    "train_file": "/foo/train.csv",
+                                    "test_file": "/foo/test.csv",
+                                    "trim_min": 1,
+                                    "trim_max": 6,
+                                    "flag_column": "[advisories]",
+                                    "model": 'LinearRegression'},
+                                   configdir='/path/to',
+                                   filename="file.json")
+
             eq_(config.filepath, abspath(filepath))
             assert len(warning_list) == 1  # we get one deprecation warning here
             assert issubclass(warning_list[0].category, DeprecationWarning)
-
 
     # this is a test for an attribute that will be
     # deprecated
     def test_set_filepath(self):
         with warnings.catch_warnings(record=True) as warning_list:
             new_file_path = '/newpath/to/new.json'
-            config = Configuration({"flag_column": "[advisories]"},
-                                   configdir='/path/to/',
-                                   filename='file.json',)
+            config = Configuration({"experiment_id": '001',
+                                    "train_file": "/foo/train.csv",
+                                    "test_file": "/foo/test.csv",
+                                    "trim_min": 1,
+                                    "trim_max": 6,
+                                    "flag_column": "[advisories]",
+                                    "model": 'LinearRegression'},
+                                   configdir='/path/to',
+                                   filename="file.json")
+
             config.filepath = new_file_path  # first deprecation warning
             eq_(config._filename, 'new.json')
             eq_(config.configdir, abspath('/newpath/to'))
@@ -848,15 +919,30 @@ class TestConfiguration:
 
     def test_get_configdir(self):
         configdir = '/path/to/dir/'
-        config = Configuration({"flag_column": "[advisories]"},
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                configdir=configdir)
+
         eq_(config.configdir, abspath(configdir))
 
     def test_set_configdir(self):
         configdir = '/path/to/dir/'
         new_configdir = 'path/that/is/new/'
-        config = Configuration({"flag_column": "[advisories]"},
+
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                configdir=configdir)
+
         config.configdir = new_configdir
         eq_(config.configdir, abspath(new_configdir))
 
@@ -867,76 +953,153 @@ class TestConfiguration:
                                configdir=configdir)
         config.configdir = None
 
-
     def test_get_filename(self):
         filename = 'file.json'
-        config = Configuration({"flag_column": "[advisories]"},
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                filename=filename)
+
         eq_(config.filename, filename)
 
     def test_set_filename(self):
         filename = 'file.json'
         new_filename = 'new_file.json'
-        config = Configuration({"flag_column": "[advisories]"},
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                filename=filename)
+
         config.filename = new_filename
         eq_(config.filename, new_filename)
 
     def test_get_context(self):
         context = 'rsmtool'
-        config = Configuration({"flag_column": "[advisories]"},
+
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                context=context)
         eq_(config.context, context)
 
     def test_set_context(self):
         context = 'rsmtool'
         new_context = 'rsmcompare'
-        config = Configuration({"flag_column": "[advisories]"},
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'},
                                context=context)
         config.context = new_context
         eq_(config.context, new_context)
 
     def test_get(self):
-        config = Configuration({"flag_column": "[advisories]"})
+        config = Configuration({"experiment_id": '001',
+                                "train_file": "/foo/train.csv",
+                                "test_file": "/foo/test.csv",
+                                "trim_min": 1,
+                                "trim_max": 6,
+                                "flag_column": "[advisories]",
+                                "model": 'LinearRegression'})
+
         eq_(config.get('flag_column'), "[advisories]")
         eq_(config.get('fasdfasfasdfa', 'hi'), 'hi')
 
     def test_to_dict(self):
-        dictionary = {"flag_column": "abc", "other_column": 'xyz'}
-        config = Configuration(dictionary)
-        eq_(config.to_dict(), dictionary)
+        configdict = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "flag_column": "abc",
+                      "model": 'LinearRegression'}
+
+        config = Configuration(configdict)
+        for key in configdict:
+            eq_(config[key], configdict[key])
 
     def test_keys(self):
-        dictionary = {"flag_column": "abc", "other_column": 'xyz'}
-        keys = ['flag_column', 'other_column']
-        config = Configuration(dictionary)
-        eq_(sorted(config.keys()), sorted(keys))
+        configdict = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "flag_column": "abc",
+                      "model": 'LinearRegression'}
+
+        config = Configuration(configdict)
+        given_keys = configdict.keys()
+        computed_keys = config.keys()
+        assert all([given_key in computed_keys for given_key in given_keys])
 
     def test_values(self):
-        dictionary = {"flag_column": "abc", "other_column": 'xyz'}
-        values = ['abc', 'xyz']
-        config = Configuration(dictionary)
-        eq_(sorted(config.values()), sorted(values))
+        configdict = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "flag_column": "abc",
+                      "model": 'LinearRegression'}
+
+        config = Configuration(configdict)
+        given_values = configdict.values()
+        computed_values = config.values()
+        assert all([given_value in computed_values for given_value in given_values])
 
     def test_items(self):
-        dictionary = {"flag_column": "abc", "other_column": 'xyz'}
-        items = [('flag_column', 'abc'), ('other_column', 'xyz')]
-        config = Configuration(dictionary)
-        eq_(sorted(config.items()), sorted(items))
+        configdict = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "flag_column": "abc",
+                      "model": 'LinearRegression'}
+
+        config = Configuration(configdict)
+        given_items = configdict.items()
+        computed_items = config.items()
+        assert all([given_item in computed_items for given_item in given_items])
 
     def test_save(self):
-        dictionary = {"experiment_id": '001', "flag_column": "abc"}
+        dictionary = {'experiment_id': '001',
+                      'train_file': 'path/to/train.tsv',
+                      'test_file': 'path/to/test.tsv',
+                      "flag_column": "abc",
+                      "model": 'LinearRegression'}
+
         config = Configuration(dictionary)
         config.save()
 
-        out_path = 'output/001_rsmtool.json'
-        with open(out_path) as buff:
+        with open('output/001_rsmtool.json', 'r') as buff:
             config_new = json.loads(buff.read())
+
         rmtree('output')
-        eq_(config_new, dictionary)
+        for key in dictionary:
+            eq_(config_new[key], dictionary[key])
 
     def test_save_rsmcompare(self):
-        dictionary = {"comparison_id": '001'}
+        dictionary = {"comparison_id": '001',
+                      "experiment_id_old": 'foo',
+                      "experiment_dir_old": 'foo',
+                      "experiment_id_new": 'bar',
+                      "experiment_dir_new": 'bar',
+                      "description_old": "foo",
+                      "description_new": "bar"}
         config = Configuration(dictionary,
                                context='rsmcompare')
         config.save()
@@ -945,10 +1108,11 @@ class TestConfiguration:
         with open(out_path) as buff:
             config_new = json.loads(buff.read())
         rmtree('output')
-        eq_(config_new, dictionary)
+        for key in dictionary:
+            eq_(config_new[key], dictionary[key])
 
     def test_save_rsmsummarize(self):
-        dictionary = {"summary_id": '001'}
+        dictionary = {"summary_id": '001', 'experiment_dirs': ['a', 'b', 'c']}
         config = Configuration(dictionary,
                                context='rsmsummarize')
         config.save()
@@ -957,50 +1121,83 @@ class TestConfiguration:
         with open(out_path) as buff:
             config_new = json.loads(buff.read())
         rmtree('output')
-        eq_(config_new, dictionary)
+        for key in dictionary:
+            eq_(config_new[key], dictionary[key])
 
     def test_check_exclude_listwise_true(self):
-        dictionary = {"experiment_id": '001', "min_items_per_candidate": 4}
+        dictionary = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "min_items_per_candidate": 4,
+                      "candidate_column": "candidate",
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         exclude_list_wise = config.check_exclude_listwise()
         eq_(exclude_list_wise, True)
 
     def test_check_exclude_listwise_false(self):
-        dictionary = {"experiment_id": '001'}
+        dictionary = {"experiment_id": '001',
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         exclude_list_wise = config.check_exclude_listwise()
         eq_(exclude_list_wise, False)
 
     def test_get_trim_min_max_tolerance_none(self):
-        dictionary = {"experiment_id": '001'}
+        dictionary = {'experiment_id': '001',
+                      'id_column': 'A',
+                      'candidate_column': 'B',
+                      'train_file': 'path/to/train.tsv',
+                      'test_file': 'path/to/test.tsv',
+                      'features': 'path/to/features.csv',
+                      "model": 'LinearRegression',
+                      'subgroups': ['C']}
+
         config = Configuration(dictionary)
         trim_min_max_tolerance = config.get_trim_min_max_tolerance()
-        eq_(trim_min_max_tolerance, (None, None, None))
+        eq_(trim_min_max_tolerance, (None, None, 0.4998))
 
     def test_get_trim_min_max_no_tolerance(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        dictionary = {"experiment_id": '001',
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         trim_min_max_tolerance = config.get_trim_min_max_tolerance()
-        eq_(trim_min_max_tolerance, (1.0, 6.0, None))
+        eq_(trim_min_max_tolerance, (1.0, 6.0, 0.4998))
 
     def test_get_trim_min_max_values_tolerance(self):
         dictionary = {"experiment_id": '001',
-                      'trim_min': 1,
-                      'trim_max': 6,
-                      'trim_tolerance': 0.49}
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "trim_tolerance": 0.51,
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         trim_min_max_tolerance = config.get_trim_min_max_tolerance()
-        eq_(trim_min_max_tolerance, (1.0, 6.0, 0.49))
+        eq_(trim_min_max_tolerance, (1.0, 6.0, 0.51))
 
     def test_get_trim_min_max_deprecated(self):
-        dictionary = {"experiment_id": '001', 'trim_min': 1, 'trim_max': 6}
+        dictionary = {"experiment_id": '001',
+                      "train_file": '/foo/train.csv',
+                      "test_file": '/foo/test.csv',
+                      "trim_min": 1,
+                      "trim_max": 6,
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         trim_min_max = config.get_trim_min_max()
         eq_(trim_min_max, (1.0, 6.0))
 
     def test_get_trim_tolerance_no_min_max(self):
         dictionary = {"experiment_id": '001',
-                      'trim_tolerance': 0.49}
+                      "trim_tolerance": 0.49,
+                      "train_file": "/foo/train.csv",
+                      "test_file": "/foo/test.csv",
+                      "model": 'LinearRegression'}
         config = Configuration(dictionary)
         trim_min_max_tolerance = config.get_trim_min_max_tolerance()
         eq_(trim_min_max_tolerance, (None, None, 0.49))
@@ -1013,11 +1210,13 @@ class TestConfiguration:
 
         expected = (filenames, filepaths)
 
-        dictionary = {'id_column': 'A',
+        dictionary = {'experiment_id': '001',
+                      'id_column': 'A',
                       'candidate_column': 'B',
                       'train_file': 'path/to/train.tsv',
                       'test_file': 'path/to/test.tsv',
                       'features': 'path/to/features.csv',
+                      "model": 'LinearRegression',
                       'subgroups': ['C']}
         config = Configuration(dictionary)
         values_for_reader = config.get_names_and_paths(['train_file', 'test_file',
@@ -1035,11 +1234,13 @@ class TestConfiguration:
 
         expected = (filenames, filepaths)
 
-        dictionary = {'id_column': 'A',
+        dictionary = {'experiment_id': '001',
+                      'id_column': 'A',
                       'candidate_column': 'B',
                       'train_file': 'path/to/train.tsv',
                       'test_file': 'path/to/test.tsv',
                       'feature_subset_file': 'path/to/feature_subset.csv',
+                      'model': 'LinearRegression',
                       'subgroups': ['C']}
         config = Configuration(dictionary)
         values_for_reader = config.get_names_and_paths(['train_file', 'test_file',
@@ -1056,11 +1257,13 @@ class TestConfiguration:
 
         expected = (filenames, filepaths)
 
-        dictionary = {'id_column': 'A',
+        dictionary = {'experiment_id': '001',
+                      'id_column': 'A',
                       'candidate_column': 'B',
                       'train_file': 'path/to/train.tsv',
                       'test_file': 'path/to/test.tsv',
                       'features': ['FEATURE1', 'FEATURE2'],
+                      'model': 'LinearRegression',
                       'subgroups': ['C']}
         config = Configuration(dictionary)
         values_for_reader = config.get_names_and_paths(['train_file', 'test_file',

--- a/tests/test_experiment_rsmcompare.py
+++ b/tests/test_experiment_rsmcompare.py
@@ -8,7 +8,7 @@ from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool import run_comparison
-from rsmtool.configuration_parser import ConfigurationParser
+from rsmtool.configuration_parser import Configuration
 from rsmtool.test_utils import (check_run_comparison,
                                 copy_data_files,
                                 do_run_comparison)
@@ -75,10 +75,9 @@ def test_run_experiment_lr_compare_with_object():
                    "subgroups": ["QUESTION"]
                    }
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict,
-                                        configdir=configdir)
-    config_obj = config_parser.normalize_validate_and_process_config(context='rsmcompare')
+    config_obj = Configuration(config_dict,
+                               context='rsmcompare',
+                               configdir=configdir)
 
     check_run_comparison(source,
                          experiment_id,

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -10,7 +10,7 @@ from parameterized import param, parameterized
 
 from rsmtool import run_evaluation
 
-from rsmtool.configuration_parser import ConfigurationParser
+from rsmtool.configuration_parser import Configuration
 from rsmtool.test_utils import (check_file_output,
                                 check_report,
                                 check_run_evaluation,
@@ -58,8 +58,9 @@ def test_run_experiment_parameterized(*args, **kwargs):
 
 
 def test_run_experiment_lr_eval_with_cfg():
-
-    # basic evaluation experiment using rsmeval
+    '''
+    test rsmeval using a configuration file
+    '''
 
     source = 'lr-eval-cfg'
     experiment_id = 'lr_eval_cfg'
@@ -87,7 +88,7 @@ def test_run_experiment_lr_eval_with_cfg():
 
 def test_run_experiment_lr_eval_with_object():
     '''
-    test rsmeval using the Configuration object, rather than a file
+    test rsmeval using a Configuration object, rather than a file
     '''
 
     source = 'lr-eval-object'
@@ -109,10 +110,7 @@ def test_run_experiment_lr_eval_with_object():
                    "trim_min": 1,
                    "trim_max": 6}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict,
-                                        configdir=configdir)
-    config_obj = config_parser.normalize_validate_and_process_config(context='rsmeval')
+    config_obj = Configuration(config_dict, context='rsmeval', configdir=configdir)
 
     check_run_evaluation(source,
                          experiment_id,

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -10,7 +10,7 @@ from parameterized import param, parameterized
 
 from rsmtool import compute_and_save_predictions
 
-from rsmtool.configuration_parser import ConfigurationParser
+from rsmtool.configuration_parser import Configuration
 from rsmtool.test_utils import (check_file_output,
                                 check_report,
                                 check_scaled_coefficients,
@@ -121,10 +121,9 @@ def test_run_experiment_lr_predict_with_object():
                    "experiment_id": "lr"
                    }
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict,
-                                        configdir=configdir)
-    config_obj = config_parser.normalize_validate_and_process_config(context='rsmpredict')
+    config_obj = Configuration(config_dict,
+                               context='rsmpredict',
+                               configdir=configdir)
 
     check_run_prediction(source,
                          given_test_dir=rsmtool_test_dir,

--- a/tests/test_experiment_rsmsummarize.py
+++ b/tests/test_experiment_rsmsummarize.py
@@ -1,20 +1,17 @@
 import os
 import tempfile
 
-from glob import glob
 from os import getcwd
-from os.path import basename, exists, join
+from os.path import join
 
 from nose.tools import raises
 from parameterized import param, parameterized
 
 from rsmtool import run_summary
 
-from rsmtool.configuration_parser import ConfigurationParser
+from rsmtool.configuration_parser import Configuration
 
-from rsmtool.test_utils import (check_file_output,
-                                check_report,
-                                check_run_summary,
+from rsmtool.test_utils import (check_run_summary,
                                 copy_data_files,
                                 do_run_summary)
 
@@ -49,13 +46,13 @@ def test_run_experiment_parameterized(*args, **kwargs):
 def test_run_experiment_lr_summary_with_object():
     '''
     test rsmsummarize using the Configuration object, rather than a file;
-    we set the configuration directory to point to the
-    test directory
-    to ensure that the results are identical to what we would expect if we had
-    run this test with a configuration file instead.
     '''
+
     source = 'lr-self-summary-object'
 
+    # we set the configuration directory to point to the test directory
+    # to ensure that the results are identical to what we would expect
+    # if we had run this test with a configuration file instead
     configdir = join(rsmtool_test_dir,
                      'data',
                      'experiments',
@@ -65,10 +62,9 @@ def test_run_experiment_lr_summary_with_object():
                    "experiment_dirs": ["lr-subgroups", "lr-subgroups", "lr-subgroups"],
                    "description": "Comparison of rsmtool experiment with itself."}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict,
-                                        configdir=configdir)
-    config_obj = config_parser.normalize_validate_and_process_config(context='rsmsummarize')
+    config_obj = Configuration(config_dict,
+                               context='rsmsummarize',
+                               configdir=configdir)
 
     check_run_summary(source, config_obj_or_dict=config_obj)
 
@@ -114,9 +110,9 @@ def test_run_experiment_lr_summary_no_trim():
                    "experiment_dirs": ["lr-subgroups1", "lr-subgroups2", "lr-subgroups3"],
                    "description": "Comparison of rsmtool without trim values"}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict, configdir=config_dir)
-    config_obj = config_parser.normalize_validate_and_process_config(context='rsmsummarize')
+    config_obj = Configuration(config_dict,
+                               context='rsmsummarize',
+                               configdir=config_dir)
 
     check_run_summary(source, config_obj_or_dict=config_obj)
 

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -11,7 +11,7 @@ from parameterized import param, parameterized
 
 from rsmtool import run_experiment
 
-from rsmtool.configuration_parser import ConfigurationParser
+from rsmtool.configuration_parser import Configuration
 from rsmtool.test_utils import (check_file_output,
                                 check_report,
                                 check_scaled_coefficients,
@@ -85,11 +85,10 @@ def test_run_experiment_lr_with_cfg():
     yield check_report, html_report
 
 
-
 def test_run_experiment_lr_with_object_and_configdir():
-
-    # test rsmtool using the Configuration object, rather than a file;
-    # with specified `configdir` attribute
+    '''
+    test rsmtool using a Configuration object and specified configdir
+    '''
 
     source = 'lr-object'
     experiment_id = 'lr_object'
@@ -112,9 +111,7 @@ def test_run_experiment_lr_with_object_and_configdir():
                    "experiment_id": "lr_object",
                    "description": "Using all features with an LinearRegression model."}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict, configdir=configdir)
-    config_obj = config_parser.normalize_validate_and_process_config()
+    config_obj = Configuration(config_dict, configdir=configdir)
 
     check_run_experiment(source,
                          experiment_id,
@@ -122,18 +119,14 @@ def test_run_experiment_lr_with_object_and_configdir():
 
 
 def test_run_experiment_lr_with_object_no_configdir():
-
-    # test rsmtool using the Configuration object, rather than a file;
-    # without passing configdir attribute
-    # to test whether the default setting of os.getcwd() is working
-    # correctly
-
+    '''
+    test rsmtool using a Configuration object and no specified configdir
+    '''
     source = 'lr-object-no-path'
     experiment_id = 'lr_object_no_path'
 
     # set up a temporary directory since
     # we will be using getcwd
-
     old_file_dict = {'train': 'data/files/train.csv',
                      'test': 'data/files/test.csv',
                      'features': 'data/experiments/lr-object-no-path/features.csv'}
@@ -156,9 +149,7 @@ def test_run_experiment_lr_with_object_no_configdir():
                    "experiment_id": "lr_object_no_path",
                    "description": "Using all features with an LinearRegression model."}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict)
-    config_obj = config_parser.normalize_validate_and_process_config()
+    config_obj = Configuration(config_dict)
 
     check_run_experiment(source,
                          experiment_id,
@@ -199,8 +190,9 @@ def test_run_experiment_lr_with_dictionary():
 
 @raises(AttributeError)
 def test_run_experiment_lr_with_object_and_filepath():
-    # This test checks for a rare potential use case where a user
-    # is trying to pass an old Configuration object
+    '''
+    test for rare use case where an old Configuration object is passed
+    '''
     source = 'lr-object'
     experiment_id = 'lr_object'
 
@@ -223,9 +215,8 @@ def test_run_experiment_lr_with_object_and_filepath():
                    "experiment_id": "lr_object",
                    "description": "Using all features with an LinearRegression model."}
 
-    config_parser = ConfigurationParser()
-    config_parser.load_config_from_dict(config_dict)
-    config_obj = config_parser.normalize_validate_and_process_config()
+    config_obj = Configuration(config_dict)
+
     # we catch the deprecation warning triggered by this line
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=DeprecationWarning)


### PR DESCRIPTION
**[Note: This PR supersedes #386].**

In our discussions, we recently found `configuration_parser.py` to be significantly over-engineered and a bit unwieldy to use. This PR attempts to fix that via a refactoring of the two main classes: `Configuration` and `ConfigurationParser`. There are also resulting changes to tests and other modules. Specifically:

1. The `Configuration` class is now instantiated using a dictionary so there's no need for special methods to deal with dictionaries. 

2. `ConfigurationParser` is now used only to parse configuration files (JSON or CFG). You create an instance for a given file and then call `.parse()` that returns a `Configuration` instance. The methods `normalize_config()`, `process_config()`, and `validate_config()` are all now class methods that accept a dictionary as input and return a dictionary as output. The private attribute `_config` no longer exists which makes operation explicit and not via side-effects. 

3. The classes `JSONConfigurationParser` and `CFGConfigurationParser` no longer exist. They have been replaced with private methods for `ConfigurationParser` called `_parse_json_file()` and `_parse_cfg_file()`. 

4. When `ConfigurationParser.parse()` is called, it calls the appropriate private method to read in the file into a Python dictionary. Then it normalizes, processes, and validates that dictionary. Finally, it instantiates a Configuration object using the validated dictionary and returns it.

5. If a `Configuration` object is instantiated directly using the initializer, the input dictionary is also normalized, processed, and validated. This makes it so that experiment configurations are _always_ normalized, processed, and validated whether used via a file or directly.

6. There's a new function called `configure()` added to `configuration_parser.py` that contains the shared code from all of the tools for dealing with different types of inputs (strings, paths, objects, and dictionaries). [This is the part from  #386 essentially].

7. There were a few places in `preprocessor.py` and `modeler.py` where we were creating new Configuration objects entirely. This led to errors in this new scenario where everything is validated because there are some internal configuration fields that do not need to be validated. To address this, we replaced this with the following: first call `configuration.copy()` (which creates a deep copy) and then add each of the internal options to the copy using `__setitem__()` which bypasses the validation. This is okay because this is _only_ for internal use.

8. There were a few tests where `trim_min` and `trim_max` are stored as strings and then being accessed as `config[trim_min]` and `config[trim_max]`. Previously, they were being converted to floats via side-effects of point 7 above. However, once we got rid of that entirely, tests started failing. The answer here is to _always_ use `Configuration.get_trim_min_max_tolerance()` method rather than trying to access the fields directly.  

9. The tests in `test_configuration_parser.py` needed to be refactored to make sure that all of the required fields are present since all the `Configuration` objects created directly are now validated.

10. If `Configuration()` was created from a dictionary and `filename` was not specified, trying to access the `filepath` attribute later errors out. I modified it so that this now explicitly raises an exception. I also added a new test for this.

11. Several other tests needed to be changed to use the new API where possible.

12. Remove some uneeded imports and tweak some docstrings here and there.

I don't believe any documentation changes are required (the API documentation will be handled by sphinx autodoc) but please let me know if I missed something.