### PR TITLE
Fix CmdOption on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 - ${HOME}/miniconda3/bin/conda update conda --yes
 
 install:
-- ${HOME}/miniconda3/bin/conda create --name rsmenv -c conda-forge -c defaults -c ets --file requirements.txt --yes --quiet
+- ${HOME}/miniconda3/bin/conda create --name rsmenv -c conda-forge -c defaults -c ets --file requirements.txt python=${TRAVIS_PYTHON_VERSION} --yes --quiet
 - ${HOME}/miniconda3/envs/rsmenv/bin/pip install nose-cov
 - ${HOME}/miniconda3/envs/rsmenv/bin/pip install -e .
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@
 
 variables:
   MPLBACKEND: Agg
+  PYTHON_VERSION: 3.8
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 variables:
   MPLBACKEND: Agg
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.7
 
 trigger:
   branches:

--- a/rsmtool/utils/commandline.py
+++ b/rsmtool/utils/commandline.py
@@ -30,9 +30,13 @@ from .constants import CHECK_FIELDS, CONFIGURATION_DOCUMENTATION_SLUGS, DEFAULTS
 # will default to `None`.
 CmdOption = namedtuple('CmdOption',
                        ['dest', 'help', 'shortname', 'longname', 'action',
-                        'default', 'required', 'nargs'],
-                       defaults=[None, None, None, None, None, None])
-
+                        'default', 'required', 'nargs'])
+# if rsmtool were python 3.7+ only, we could just use the `defaults`
+# keyword argument to specify the default values; but to support python
+# 3.6, we need to mess with the `__new__` constructor.
+# Adapted from: https://stackoverflow.com/a/18348004
+# TODO: replace this with `defaults` when we drop support for python 3.7
+CmdOption.__new__.__defaults__ = (None,) * 6
 
 def setup_rsmcmd_parser(name,
                         uses_output_directory=True,

--- a/rsmtool/utils/commandline.py
+++ b/rsmtool/utils/commandline.py
@@ -35,8 +35,9 @@ CmdOption = namedtuple('CmdOption',
 # keyword argument to specify the default values; but to support python
 # 3.6, we need to mess with the `__new__` constructor.
 # Adapted from: https://stackoverflow.com/a/18348004
-# TODO: replace this with `defaults` when we drop support for python 3.7
+# TODO: replace this with `defaults` when we drop support for python 3.6
 CmdOption.__new__.__defaults__ = (None,) * 6
+
 
 def setup_rsmcmd_parser(name,
                         uses_output_directory=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,11 +167,12 @@ class TestToolCLI:
             # and, finally, that the output was as expected
             self.validate_run_output(name, output_dir)
         else:
-            # for generate subcommands, we ignore the warnings printed to staderr
+            # for generate subcommands, we ignore the warnings printed to stderr
             subgroups = "--subgroups" in cmd
             proc = subprocess.run(shlex.split(cmd, posix='win' not in sys.platform),
                                   check=True,
-                                  capture_output=True,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.DEVNULL,
                                   encoding='utf-8')
             ok_(proc.returncode == 0)
             self.validate_generate_output(name,


### PR DESCRIPTION
This PR fixes #401. 

It does so by adding a workaround for the `defaults` keyword argument for `collections.namedtuple` that is only supported in Python 3.7+.  It also replaces the `capture_output` keyword argument for `subprocess.run()` calls that is used in `test_cli.py`.

It also make sure that Travis CI builds use Python 3.6 and that Azure ones use Python 3.8. This ensures that we are covering the two Python versions most important to us - 3.6 for internal use and the latest (3.8) for external use.

*Update*: 3.8 support is broken right now (see #403). So, we have to make do with Python 3.7 instead of 3.8 in Azure.