### PR TITLE
Display headers for consistency and PRMSE notebooks

### DIFF
--- a/rsmtool/notebooks/consistency.ipynb
+++ b/rsmtool/notebooks/consistency.ipynb
@@ -8,6 +8,8 @@
    },
    "outputs": [],
    "source": [
+    "markdown_strs = ['## Consistency']\n",
+    "\n",
     "consistency_file = join(output_dir, '{}_consistency.{}'.format(experiment_id, file_format))\n",
     "degradation_file = join(output_dir, '{}_degradation.{}'.format(experiment_id, file_format))\n",
     "disattenuation_file = join(output_dir, '{}_disattenuated_correlations.{}'.format(experiment_id, file_format))\n",
@@ -19,7 +21,7 @@
     "    df_degradation = DataReader.read_from_file(degradation_file, index_col=0)\n",
     "    df_dis_corrs = DataReader.read_from_file(disattenuation_file, index_col=0)\n",
     "    df_eval = DataReader.read_from_file(eval_file, index_col=0)\n",
-    "    markdown_strs = ['## Consistency']\n",
+    "\n",
     "    markdown_strs.append('*Note: this section assumes that the score used for evaluating machine scores '\n",
     "                         'is the score assigned by the first rater.*')\n",
     "    markdown_strs.append('### Human-human agreement')\n",
@@ -107,7 +109,11 @@
     "                                      classes=['sortable'],\n",
     "                                      float_format=float_format_func,\n",
     "                                      formatters=formatter_dict)))\n",
-    "    \n",
+    "else:  \n",
+    "    markdown_strs.append(\"The configuration file did not specify \"\n",
+    "                         \"`second_human_score_column` necessary to compute \"\n",
+    "                         \"consistency metrics.\")\n",
+    "    display(Markdown('\\n'.join(markdown_strs)))\n",
     "    \n",
     "    "
    ]
@@ -129,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/rsmtool/notebooks/consistency.ipynb
+++ b/rsmtool/notebooks/consistency.ipynb
@@ -111,7 +111,7 @@
     "                                      formatters=formatter_dict)))\n",
     "else:  \n",
     "    markdown_strs.append(\"The configuration file did not specify \"\n",
-    "                         \"`second_human_score_column` necessary to compute \"\n",
+    "                         \"`second_human_score_column` which is necessary to compute \"\n",
     "                         \"consistency metrics.\")\n",
     "    display(Markdown('\\n'.join(markdown_strs)))\n",
     "    \n",

--- a/rsmtool/notebooks/true_score_evaluation.ipynb
+++ b/rsmtool/notebooks/true_score_evaluation.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "markdown_strs = ['### True score evaluations']\n",
+    "\n",
     "raw_or_scaled = \"scaled\" if use_scaled_predictions else \"raw\"\n",
     "true_eval_file = join(output_dir, '{}_true_score_eval.{}'.format(experiment_id, file_format))\n",
     "if exists(true_eval_file): \n",
@@ -16,14 +18,13 @@
     "                     'MSE true', 'PRMSE true']\n",
     "    df_prmse = df_true_eval[prmse_columns]\n",
     "\n",
-    "    markdown_strs = ['### True score evaluations']\n",
     "    markdown_strs.append(\"The tables in this section show how well system scores can \"\n",
-    "                            \"predict *true* scores. According to Test theory, a *true* score \"\n",
-    "                            \"is a score that would have been obtained if there were no errors \"\n",
-    "                            \"in measurement. While true scores cannot be observed, the variance \"\n",
-    "                            \"of true scores and the prediction error can be estimated using observed \"\n",
-    "                            \"human scores when multiple human ratings are available for a subset of \"\n",
-    "                            \"responses.\")\n",
+    "                         \"predict *true* scores. According to Test theory, a *true* score \"\n",
+    "                         \"is a score that would have been obtained if there were no errors \"\n",
+    "                         \"in measurement. While true scores cannot be observed, the variance \"\n",
+    "                         \"of true scores and the prediction error can be estimated using observed \"\n",
+    "                         \"human scores when multiple human ratings are available for a subset of \"\n",
+    "                         \"responses.\")\n",
     "\n",
     "    if rater_error_variance is None: \n",
     "        \n",
@@ -92,7 +93,12 @@
     "    display(HTML('<span style=\"font-size:95%\">'+ df_prmse.to_html(classes=['sortable'], \n",
     "                                                               escape=False,\n",
     "                                                               float_format=float_format_func) + '</span>'))\n",
-    "    "
+    "else:\n",
+    "    markdown_strs.append(\"The configuration file did not specify \"\n",
+    "                         \"`second_human_score_column` or `rater_error_variance`. \"\n",
+    "                         \"At least one of these need to be specified to compute \"\n",
+    "                         \"evaluations against true scores.\")\n",
+    "    display(Markdown('\\n'.join(markdown_strs)))"
    ]
   }
  ],

--- a/rsmtool/notebooks/true_score_evaluation.ipynb
+++ b/rsmtool/notebooks/true_score_evaluation.ipynb
@@ -96,7 +96,7 @@
     "else:\n",
     "    markdown_strs.append(\"The configuration file did not specify \"\n",
     "                         \"`second_human_score_column` or `rater_error_variance`. \"\n",
-    "                         \"At least one of these need to be specified to compute \"\n",
+    "                         \"At least one of these must be specified to compute \"\n",
     "                         \"evaluations against true scores.\")\n",
     "    display(Markdown('\\n'.join(markdown_strs)))"
    ]


### PR DESCRIPTION
This PR addresses #315 .
If the `consistency` and `true_score_evaluations` are included into the report, the headers will now always be displayed. If there is no `second_human_score`, the report shows that no data was available. The user can always exclude those sections from the list if they don't want to see empty headers. 