### PR TITLE
Set test directory based on environment variable first

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,15 @@ from nose.tools import assert_raises, eq_, ok_
 from rsmtool.test_utils import (check_file_output,
                                 check_generated_output,
                                 check_report,
-                                collect_warning_messages_from_report,
-                                rsmtool_test_dir)
+                                collect_warning_messages_from_report)
+
+# allow test directory to be set via an environment variable
+# which is needed for package testing
+TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 class TestToolCLI:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import argparse
 import tempfile
+import os
 import warnings
 
 from io import StringIO
@@ -26,8 +27,6 @@ from skll import FeatureSet, Learner
 from skll.metrics import kappa
 
 from rsmtool.configuration_parser import Configuration
-from rsmtool.test_utils import rsmtool_test_dir
-
 from rsmtool.utils.commandline import (CmdOption,
                                        ConfigurationGenerator,
                                        InteractiveField,
@@ -52,6 +51,15 @@ from rsmtool.utils.notebook import (float_format_func,
                                     compute_subgroup_plot_params,
                                     get_thumbnail_as_html,
                                     get_files_as_html)
+
+
+# allow test directory to be set via an environment variable
+# which is needed for package testing
+TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 def test_int_to_float():

--- a/tests/test_utils_prmse.py
+++ b/tests/test_utils_prmse.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 
@@ -19,9 +21,13 @@ from rsmtool.utils.prmse import (get_true_score_evaluations,
                                  get_n_human_scores)
 
 
-# get the directory containing the tests
-test_dir = Path(__file__).parent
-
+# allow test directory to be set via an environment variable
+# which is needed for package testing
+TEST_DIR = os.environ.get('TESTDIR', None)
+if TEST_DIR:
+    rsmtool_test_dir = TEST_DIR
+else:
+    from rsmtool.test_utils import rsmtool_test_dir
 
 
 def test_compute_n_human_scores():
@@ -82,8 +88,6 @@ def test_get_true_score_evaluations_single_human_no_ve():
     get_true_score_evaluations(df, 'system', 'sc1')
 
 
-
-
 class TestPrmseJohnsonData():
 
     '''
@@ -94,13 +98,12 @@ class TestPrmseJohnsonData():
     '''
 
     def setUp(self):
-        full_matrix_file = test_dir / 'data' / 'files' / 'prmse_data.csv'
-        sparse_matrix_file = test_dir / 'data' / 'files' / 'prmse_data_sparse_matrix.csv'
+        full_matrix_file = Path(rsmtool_test_dir) / 'data' / 'files' / 'prmse_data.csv'
+        sparse_matrix_file = Path(rsmtool_test_dir) / 'data' / 'files' / 'prmse_data_sparse_matrix.csv'
         self.data_full = pd.read_csv(full_matrix_file)
         self.data_sparse = pd.read_csv(sparse_matrix_file)
         self.human_score_columns = ['h1', 'h2', 'h3', 'h4']
         self.system_score_columns = ['system']
-
 
     def test_variance_of_errors_full_matrix(self):
         human_scores = self.human_score_columns
@@ -108,7 +111,6 @@ class TestPrmseJohnsonData():
         variance_errors_human = variance_of_errors(df_humans)
         expected_v_e = 0.509375
         eq_(variance_errors_human, expected_v_e)
-
 
     def test_variance_of_errors_sparse_matrix(self):
         human_scores = self.human_score_columns
@@ -163,7 +165,6 @@ class TestPrmseJohnsonData():
                        df_humans,
                        variance_errors_human)
         assert_almost_equal(mse, expected_mse_true, 7)
-
 
     def test_mse_sparse_matrix_computed_ve(self):
         human_scores = self.human_score_columns


### PR DESCRIPTION
Modify `test_utils.py`, `test_cli.py`, and `test_utils_prmse.py` to respect the `TESTDIR` environment variable which is used to run tests with conda and PyPI packages.