### PR TITLE
RSMTool v8.0.1 Release PR

### DIFF
--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -31,9 +31,9 @@ This process is only meant for the project administrators, not users and develop
 
 8. Then run some tests from a RSMTool working copy. If the TestPyPI package works, then move on to the next step. If it doesn't, figure out why and rebuild and re-upload the package.
 
-9. Build the new generic conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool`` and that the latest version of ``numpy`` is ``1.18``)::
+9. Build the new generic conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool`` and that the latest version of ``numpy`` is ``1.19``)::
 
-    conda build -c conda-forge -c ets --numpy=1.18 .
+    conda build -c conda-forge -c ets --numpy=1.19 .
 
 10. Upload the package to anaconda.org using ``anaconda upload --user ets <package tarball>``. You will need to have the appropriate permissions for the ``ets`` organization. 
 

--- a/rsmtool/version.py
+++ b/rsmtool/version.py
@@ -3,5 +3,5 @@ This module exists solely for version information so we only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 """
 
-__version__ = '8.0.0'
+__version__ = '8.0.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
- Update version number.
- Update numpy version in conda build instructions.

Conda and PyPI package already built and uploaded. Package testing builds passing.