### PR TITLE
Update report generation to work with latest nbconvert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ jupyter
 ipython<7.17
 nose
 notebook
-nbconvert<6.0
 numpy
 pandas
 seaborn

--- a/rsmtool/notebooks/templates/report.tpl
+++ b/rsmtool/notebooks/templates/report.tpl
@@ -1,4 +1,4 @@
-{%- extends 'full.tpl' -%}
+{%- extends 'index.html.j2' -%}
 
 {% block input %}
 {%- endblock input %}

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -320,8 +320,9 @@ class Reporter:
         # set a high timeout for datasets with a large number of features
         report_config = Config({'ExecutePreprocessor': {'enabled': True,
                                                         'timeout': 3600},
-                                'HTMLExporter': {'template_path': [template_path],
-                                                 'template_file': 'report.tpl'}})
+                                'HTMLExporter': {"template_name": "classic",
+                                                 "template_file": join(template_path,
+                                                                       'report.tpl')}})
 
         exportHtml = HTMLExporter(config=report_config)
         output, _ = exportHtml.from_filename(notebook_file)

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -9,9 +9,11 @@ Classes for dealing with report generation.
 """
 
 import argparse
+import asyncio
 import logging
 import json
 import os
+import sys
 
 from os.path import (abspath,
                      basename,
@@ -316,6 +318,15 @@ class Reporter:
         This function is also exposed as the
         :ref:`render_notebook <render_notebook>` command-line utility.
         """
+
+        # `nbconvert` uses `asyncio` which uses an entirely default
+        # implemention of the event loop on Windows for Cpython 3.8
+        # which breaks the report generation unless we include the
+        # following workaround
+        if (sys.version_info[0] == 3 and
+                sys.version_info[1] >= 8 and
+                sys.platform.startswith('win')):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
         # set a high timeout for datasets with a large number of features
         report_config = Config({'ExecutePreprocessor': {'enabled': True,


### PR DESCRIPTION
This PR closes #471. 

- Update the reporting code and template.
- Remove nbconvert pin.
- Include asyncio + CPython 3.8  workaround to make sure things work on Windows.