### PR TITLE
updated dependencies to make it py38-compatible

### DIFF
--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../../../rsmtool
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - cd $SRC_DIR

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ doc2dash
 jupyter
 nose
 notebook
-numpy==1.14.6
-pandas==0.23.4
+numpy
+pandas
 seaborn
-skll==2.0.0
+skll==2.0.1
 statsmodels
 coverage
 coveralls


### PR DESCRIPTION
This is a patch for 7.1.0 version of rsmtool to make it py38-compatible