### PR TITLE
Drop python3.6 support in main.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.7
   install:
     - requirements: doc/requirements.txt
   system_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- 3.6
+- 3.7
 notifications:
   email: false
   webhooks: https://coveralls.io/webhook

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ To get started with RSMTool, please see the extensive `official documentation <h
 Requirements
 ------------
 
-- Python >=3.6, <3.9
+- Python >=3.7, <3.10
 - ``numpy``
 - ``scipy``
 - ``scikit-learn``

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -2,7 +2,7 @@
 
 Installation
 ============
-Note that RSMTool currently works with Python 3.6, 3.7, and 3.8.
+Note that RSMTool currently works with Python 3.7, 3.8, and 3.9.
 
 Installing with conda
 ----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 doc2dash
 jupyter
-ipython<7.17
+ipython
 nose
 notebook
 numpy

--- a/rsmtool/utils/commandline.py
+++ b/rsmtool/utils/commandline.py
@@ -40,13 +40,8 @@ from .constants import (CHECK_FIELDS,
 # will default to `None`.
 CmdOption = namedtuple('CmdOption',
                        ['dest', 'help', 'shortname', 'longname', 'action',
-                        'default', 'required', 'nargs'])
-# if rsmtool were python 3.7+ only, we could just use the `defaults`
-# keyword argument to specify the default values; but to support python
-# 3.6, we need to mess with the `__new__` constructor.
-# Adapted from: https://stackoverflow.com/a/18348004
-# TODO: replace this with `defaults` when we drop support for python 3.6
-CmdOption.__new__.__defaults__ = (None,) * 6
+                        'default', 'required', 'nargs'],
+                       defaults=(None,) * 6)
 
 
 def setup_rsmcmd_parser(name,


### PR DESCRIPTION
Same changes as #498 but applied to `main` instead of `stable`. 