### PR TITLE
Add steps to release docs for more clarity

### DIFF
--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -11,11 +11,12 @@ This process is only meant for the project administrators, not users and develop
 
     .. note:: 
 
-        Some input files might be updated or changed due to changes in SKLL or scikit-learn packages, for example, the inputs and outputs for linearsvr. In this case, the tests need to be rerun and fixed. The process is similar to Example 2 under `Writing new functional tests <https://rsmtool.readthedocs.io/en/stable/contributing.html#writing-new-functional-tests>`_. You can also see `this pull request <https://github.com/EducationalTestingService/rsmtool/pull/525>`_ for more information. 
+        Several files have been excluded from the repository due to their non-deterministic nature so please do not add them back to the repository. The following files are currently excluded:
 
-    .. note:: 
-
-        Fairness test files have been excluded from the repository due to their non-deterministic nature so please do not add them back to the repository. More information on these files can be found in `this pull request <https://github.com/EducationalTestingService/rsmtool/pull/410>`_.
+            * Fairness test files for `lr-eval-system-score-constant` test
+            * Predictions and all evaluation files for `linearsvr` test. 
+     
+        Note that the full set of outputs from these test files are also used as input for `rsmcompare` and `rsmsummarize` tests. These *input* files need to be updated following the process under **Example 2** in `Writing new functional tests <https://rsmtool.readthedocs.io/en/stable/contributing.html#writing-new-functional-tests>`_. You can also see `this pull request <https://github.com/EducationalTestingService/rsmtool/pull/525>`_ for more information. 
 
 #. Create a release branch ``release/XX`` on GitHub.
 
@@ -74,4 +75,3 @@ This process is only meant for the project administrators, not users and develop
 #. Send an email around at ETS announcing the release and the changes.
 
 #. Create a `Dash <https://kapeli.com/dash>`_ docset from the documentation by following the instructions :ref:`here <dash_docset>`.
-

--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -3,6 +3,8 @@ RSMTool Release Process
 
 This process is only meant for the project administrators, not users and developers.
 
+#. Recreate the development environment so all unpinned packages are updated to their latest versions. See instructions for this `here <https://rsmtool.readthedocs.io/en/main/contributing.html#setting-up>`_.
+
 #. Make sure any and all tests are passing in ``main``. Make sure you have also run tests locally in strict mode (``STRICT=1 nosetests --nologcapture tests``) to catch any warnings in the HTML report that can be fixed before the release.
 
 #. Run the ``tests/update_files.py`` script with the appropriate arguments to make sure that all test data in the new release have correct experiment ids and filenames. If any (non-model) files need to be changed this should be investigated before the branch is released. Please see more details about running this `here <https://rsmtool.readthedocs.io/en/stable/contributing.html#writing-new-functional-tests>`_.

--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -9,6 +9,14 @@ This process is only meant for the project administrators, not users and develop
 
 #. Run the ``tests/update_files.py`` script with the appropriate arguments to make sure that all test data in the new release have correct experiment ids and filenames. If any (non-model) files need to be changed this should be investigated before the branch is released. Please see more details about running this `here <https://rsmtool.readthedocs.io/en/stable/contributing.html#writing-new-functional-tests>`_.
 
+    .. note:: 
+
+        Some input files might be updated or changed due to changes in SKLL or scikit-learn packages, for example, the inputs and outputs for linearsvr. In this case, the tests need to be rerun and fixed. The process is similar to Example 2 under `Writing new functional tests <https://rsmtool.readthedocs.io/en/stable/contributing.html#writing-new-functional-tests>`_. You can also see `this pull request <https://github.com/EducationalTestingService/rsmtool/pull/525>`_ for more information. 
+
+    .. note:: 
+
+        Fairness test files have been excluded from the repository due to their non-deterministic nature so please do not add them back to the repository. More information on these files can be found in `this pull request <https://github.com/EducationalTestingService/rsmtool/pull/410>`_.
+
 #. Create a release branch ``release/XX`` on GitHub.
 
 #. In the release branch:


### PR DESCRIPTION
Documenting scenario where changes are made to input and output test files like linearsvr. This in turn affects rsmcompare and rsmsummarize so the test files have to be updated.