### PR TITLE
538 warnings in reports

### DIFF
--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -799,6 +799,13 @@ def check_report(html_file,
             if m_warning:
                 # actual text of warning is in the next line of HTML file
                 warning_text = htmlf.readline()
+
+                # NOTE: there is a separate function
+                # ``collect_warning_messages_from_the_report`` that once again
+                # checks for warnings. The warnings filtered here might still
+                # be flagged by that function.
+                # See https://github.com/EducationalTestingService/rsmtool/issues/539
+
                 # we do not want to flag matlplotlib font cache warning
                 if not re.search(r'font\s*cache', warning_text, flags=re.IGNORECASE):
                     report_warnings += 1

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -212,9 +212,13 @@ class TestAnalyzer:
         # test pca when we have less samples than
         # features. In this case the number of components
         # equals to the number of samples.
-        df = pd.DataFrame({'a': range(50)})
-        for i in range(100):
-            df[i] = df['a'] * i
+        dfs = []
+        # to avoid inserting too many columns,
+        # we create a list of data frames and then
+        # concatenate them together
+        for i in range(1, 101):
+            dfs.append(pd.DataFrame({i: pd.Series(range(50)) * i}))
+        df = pd.concat(dfs, axis=1)
         (components, variance) = Analyzer.compute_pca(df, df.columns)
         assert_equal(len(components.columns), 50)
         assert_equal(len(variance.columns), 50)


### PR DESCRIPTION
This PR closes #536 and closes #538.

* Refactored test setup to avoid performance warning
* No changes were necessary for #538 since warnings came from third package. 
* Added a note to developers to flag the duplicate warning tracking (see also #539)