### PR TITLE
v8.1.2 Release

### DIFF
--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -42,7 +42,7 @@ This process is only meant for the project administrators, not users and develop
 
 #. Then run some tests from a RSMTool working copy. If the TestPyPI package works, then move on to the next step. If it doesn't, figure out why and rebuild and re-upload the package.
 
-#. Build the new generic conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool``)::
+#. Build the new conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool``)::
 
     conda build -c conda-forge -c ets .
 

--- a/rsmtool/version.py
+++ b/rsmtool/version.py
@@ -3,5 +3,5 @@ This module exists solely for version information so we only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 """
 
-__version__ = '8.1.1'
+__version__ = '8.1.2'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
Not a lot of changes - basically the version change.

[rsmtool-pip-tester](https://github.com/EducationalTestingService/rsmtool-pip-tester/pull/12) and [rsmtool-conda-tester](https://github.com/EducationalTestingService/rsmtool-conda-tester/pull/15) PRs are both passing. 

