### PR TITLE
Fix `use_thumbnails` option.

### DIFF
--- a/rsmtool/notebooks/comparison/header.ipynb
+++ b/rsmtool/notebooks/comparison/header.ipynb
@@ -47,6 +47,7 @@
     "\n",
     "from IPython import sys_info\n",
     "from IPython.display import display, HTML, Image, Javascript, Markdown, SVG\n",
+    "from matplotlib import pyplot as plt\n",
     "\n",
     "from rsmtool.comparer import Comparer\n",
     "\n",
@@ -60,7 +61,10 @@
     "                                    color_highlighter,\n",
     "                                    show_thumbnail)\n",
     "\n",
-    "from rsmtool.version import VERSION as rsmtool_version"
+    "from rsmtool.version import VERSION as rsmtool_version\n",
+    "\n",
+    "# turn off interactive plotting\n",
+    "plt.ioff()"
    ]
   },
   {

--- a/rsmtool/notebooks/comparison/model.ipynb
+++ b/rsmtool/notebooks/comparison/model.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "if 'betas' in figures_old:\n",
     "    markdown_str = '''### Feature weight graphs for the old model ({})'''.format(experiment_id_old)\n",
-    "    Markdown(markdown_str)\n",
+    "    display(Markdown(markdown_str))\n",
     "    if use_thumbnails:\n",
     "        show_thumbnail(figures_old['betas'], next(id_generator))\n",
     "    else:\n",

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -68,6 +68,9 @@
     "\n",
     "from rsmtool.version import VERSION as rsmtool_version\n",
     "\n",
+    "# turn off interactive plotting\n",
+    "plt.ioff()\n",
+    "\n",
     "sns.set_context('notebook')"
    ]
   },

--- a/rsmtool/notebooks/summary/header.ipynb
+++ b/rsmtool/notebooks/summary/header.ipynb
@@ -59,7 +59,10 @@
     "\n",
     "from rsmtool.reader import DataReader\n",
     "from rsmtool.writer import DataWriter\n",
-    "from rsmtool.version import VERSION as rsmtool_version"
+    "from rsmtool.version import VERSION as rsmtool_version\n",
+    "\n",
+    "# turn off interactive plotting\n",
+    "plt.ioff()"
    ]
   },
   {


### PR DESCRIPTION
This PR resolves #553. 

Adding `use_thumbnails = true` to a configuration file was generating both the thumbnail as well as the full-sized figure. The solution was to turn off interactive plotting in all header notebooks. 

To review, please run 2 `rsmxval` experiments:  one that uses `use_thumbnails`  and one that doesn't. Make sure that the figures show up as expected in all the reports in both experiments. Please also try an `rsmcompare` experiment separately since that is not part of `rsmxval`.