### PR TITLE
Draft: Integrate feature preprocessor as step in SKLL learner pipeline

### DIFF
--- a/rsmtool/modeler.py
+++ b/rsmtool/modeler.py
@@ -45,36 +45,22 @@ class RSMToolFeaturePreprocessor(BaseEstimator, TransformerMixin):
     dictionaries.
     """
 
-    def __init__(self, standardize_features=True):
+    def __init__(self, feature_info, standardize_features=True):
         """
         Initialize object with list of feature names, etc.
 
         Parameters
         ----------
+        feature_info : pd.DataFrame
+            Frame containing RSMTool feature preprocessing information
         standardize_features : bool, optional
             Whether or not to standardize feature values
         """
 
         self.standardize_features = standardize_features
         self.processor = FeaturePreprocessor()
-
-    def fit(self, X=None, y=None, feature_info=None):
-        """
-        Fit the feature preprocessor with some training data.
-
-        Parameters
-        ----------
-        X : iterable of feature dictionaries
-            Not used, only here for compatibility
-        y : iterable of target variable values
-            Not used, only here for compatibility
-        feature_info : pd.DataFrame
-            Feature info frame
-        """
-
         self.df_feature_info = feature_info.copy()
         self.df_feature_info.set_index("feature", inplace=True)
-        return self
 
     def transform(self, X, y=None):
         """
@@ -1284,8 +1270,9 @@ class Modeler:
 
         # Generate an `sklearn`-style feature preprocessor to be used
         # later in the model's pipeline
-        processor = RSMToolFeaturePreprocessor(standardize_features=True)
-        processor.fit(feature_info=data_container.feature_info)
+        processor = RSMToolFeaturePreprocessor(
+            feature_info=data_container.feature_info, standardize_features=True
+        )
         pipeline = Pipeline(
             [("rsmtool_feature_preprocessor", processor)] +
             list(model.pipeline.named_steps.items())


### PR DESCRIPTION
The basic idea is that one of the outputs of running RSMTool should be a model file that can be loaded and used immediately with the same type of raw features used to run the original experiment. This PR adds a named step to the SKLL learner pipeline and then also saves the pipeline separately.

```
In [1]: import joblib

In [2]: model = joblib.load(open("output/ASAP2.pipeline.model", "rb"))

In [3]: ! head -2 train.csv
ID,DISCOURSE,ORGANIZATION,GRAMMAR,MECHANICS,LENGTH,score,score2
RESPONSE_1,4.93806460126142,-0.0846667513334603,-0.316793975540994,4.65591397849462,279,3,3

In [4]: ! head -2 output/ASAP2_pred_train.csv
spkitemid,raw,sc1,scale,raw_trim,raw_trim_round,scale_trim,scale_trim_round
RESPONSE_1,3.467158796079344,3.0,3.487689689334681,3.467158796079344,3,3.487689689334681,3

In [5]: model.predict([{"DISCOURSE": 4.93806460126142, "ORGANIZATION": -0.0846667513334603, "GRAMMAR": -0.316793975540994, "MECHANICS": 4.65591397849462}])
Out[5]: array([3.4671588])
```

