### PR TITLE
Disallow negative confidence intervals.

### DIFF
--- a/rsmtool/notebooks/fairness_analyses.ipynb
+++ b/rsmtool/notebooks/fairness_analyses.ipynb
@@ -173,7 +173,7 @@
     "        df_coefs_all = pd.concat(all_coefs)\n",
     "\n",
     "        # compute the size of the confidence interval from the boundary\n",
-    "        df_coefs_all['CI'] = df_coefs_all['[0.025'] - df_coefs_all['estimate']\n",
+    "        df_coefs_all['CI'] = np.abs(df_coefs_all['[0.025'] - df_coefs_all['estimate'])\n",
     "\n",
     "        # plot the coefficients\n",
     "        with sns.axes_style('whitegrid'), sns.plotting_context('notebook', font_scale=2):\n",


### PR DESCRIPTION
Compute confidence intervals using absolute values so that we don't compute negative ones that pandas & Matplotlib complain about. 