### PR TITLE
Add workaround for broken SVGs in nbconvert

### DIFF
--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -17,6 +17,7 @@ import sys
 from os.path import abspath, basename, dirname, join, splitext
 
 from nbconvert.exporters import HTMLExporter
+from nbconvert.exporters.templateexporter import default_filters
 from traitlets.config import Config
 
 from . import HAS_RSMEXTRA
@@ -326,6 +327,15 @@ class Reporter:
                                 'HTMLExporter': {"template_name": "classic",
                                                  "template_file": join(template_path,
                                                                        'report.tpl')}})
+
+        # newer versions of nbconvert use a "clean_html" filter that
+        # break SVG rendering; so we override that filter here with
+        # a custom function that is essentially a noop. For more
+        # details, please refer to the following issue:
+        # https://github.com/EducationalTestingService/rsmtool/issues/571
+        def custom_clean_html(element):
+            return element.decode() if isinstance(element, bytes) else str(element)
+        default_filters["clean_html"] = custom_clean_html
 
         exportHtml = HTMLExporter(config=report_config)
         output, _ = exportHtml.from_filename(notebook_file)


### PR DESCRIPTION
Newer versions of nbconvert use a "clean_html" filter on SVG elements that break SVG rendering; so we override that filter here with a custom function that is essentially a noop. For more details, please refer to #571. 

To review this properly, please run the following on **both your Macs and on a Linux server** (EC2 instance will work too):
- Clone RSMTool and switch to this branch
- If you are running on your Mac, run `CONDA_SUBDIR=osx-64 mamba create -n rsmdev --file requirements.txt python=3.8` to create the conda environment. If on a Linux server, run `mamba create -n rsmdev --file requirements.txt python=3.8` instead.
-  Activate the newly created environment and run `pip install -e .`
- Run `rsmtool tests/data/experiments/lr-subgroups-with-h2/lr_subgroups_with_h2.json foobar`. 
- Run `open foobar/report/lr_subgroups_with_h2_report.html` and make sure that all the figures in the report are visible and as expected. 