### PR TITLE
Add new `fast_predict()` API method for prediction

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,8 +5,8 @@ API Documentation
 The primary method of using RSMTool is via the command-line scripts :ref:`rsmtool <usage_rsmtool>`, :ref:`rsmeval <usage_rsmeval>`, :ref:`rsmpredict <usage_rsmpredict>`, :ref:`rsmcompare <usage_rsmcompare>`, and :ref:`rsmsummarize <usage_rsmsummarize>`. However, there are certain functions in the ``rsmtool`` API that may also be useful to advanced users for use directly in their Python code. We document these functions below.
 
 .. note::
-    
-    RSMTool v5.7 and older provided the API functions ``metrics_helper``, ``convert_ipynb_to_html``, and ``remove_outliers``. These functions have now been turned into static methods for different classes. 
+
+    RSMTool v5.7 and older provided the API functions ``metrics_helper``, ``convert_ipynb_to_html``, and ``remove_outliers``. These functions have now been turned into static methods for different classes.
 
     In addition, with RSMTool v8.0 onwards, the functions ``agreement``, ``difference_of_standardized_means``, ``get_thumbnail_as_html``,  ``parse_json_with_comments``, ``partial_correlations``,  ``quadratic_weighted_kappa``, ``show_thumbnail``,  and ``standardized_mean_difference`` that ``utils.py`` had previously provided have been moved to new locations.
 
@@ -19,25 +19,25 @@ The primary method of using RSMTool is via the command-line scripts :ref:`rsmtoo
 
      from rsmtool.report import convert_ipynb_to_html
      convert_ipynb_to_html(...)
-        
+
      from rsmtool.preprocess import remove_outliers
      remove_outliers(...)
 
      from rsmtool.utils import agreement
      agreement(...)
-        
+
      from rsmtool.utils import difference_of_standardized_means
      difference_of_standardized_means(...)
-        
+
      from rsmtool.utils import partial_correlations
      partial_correlations(...)
-        
+
      from rsmtool.utils import quadratic_weighted_kappa
      quadratic_weighted_kappa(...)
-        
+
      from rsmtool.utils import standardized_mean_difference
      standardized_mean_difference(...)
-        
+
      from rsmtool.utils import parse_json_with_comments
      parse_json_with_comments(...)
 
@@ -56,25 +56,25 @@ The primary method of using RSMTool is via the command-line scripts :ref:`rsmtoo
 
      from rsmtool.reporter import Reporter
      Reporter.convert_ipynb_to_html(...)
-    
+
      from rsmtool.preprocessor import FeaturePreprocessor
      FeaturePreprocessor.remove_outliers(...)
 
      from rsmtool.utils.metrics import agreement
      agreement(...)
-    
+
      from rsmtool.utils.metrics import difference_of_standardized_means
      difference_of_standardized_means(...)
-    
+
      from rsmtool.utils.metrics import partial_correlations
      partial_correlations(...)
-    
+
      from rsmtool.utils.metrics import quadratic_weighted_kappa
      quadratic_weighted_kappa(...)
-    
+
      from rsmtool.utils.metrics import standardized_mean_difference
      standardized_mean_difference(...)
-    
+
      from rsmtool.utils.files import parse_json_with_comments
      parse_json_with_comments(...)
 
@@ -85,7 +85,7 @@ The primary method of using RSMTool is via the command-line scripts :ref:`rsmtoo
      show_thumbnail(...)
 
 .. note ::
-    In RSMTool v8.0 the API for computing ``PRMSE`` has changed. 
+    In RSMTool v8.0 the API for computing ``PRMSE`` has changed.
     See :ref:`rsmtool.utils.prmse<prmse_api>`.
 
 
@@ -97,6 +97,7 @@ The primary method of using RSMTool is via the command-line scripts :ref:`rsmtoo
 .. autofunction:: rsmtool.run_comparison
 .. autofunction:: rsmtool.run_summary
 .. autofunction:: rsmtool.compute_and_save_predictions
+.. autofunction:: rsmtool.fast_predict
 
 From :py:mod:`~rsmtool.analyzer` Module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rsmtool/__init__.py
+++ b/rsmtool/__init__.py
@@ -36,12 +36,12 @@ from .rsmeval import run_evaluation  # noqa
 
 from .rsmtool import run_experiment  # noqa
 
-from .rsmpredict import compute_and_save_predictions  # noqa
+from .rsmpredict import compute_and_save_predictions, fast_predict  # noqa
 
 from .rsmsummarize import run_summary  # noqa
 
 __all__ = ['run_experiment', 'run_evaluation', 'run_comparison',
-           'compute_and_save_predictions', 'run_summary']
+           'compute_and_save_predictions', 'fast_predict', 'run_summary']
 
 # Make sure that DeprecationWarnings are always shown
 # within this package unless we are in test mode in

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -2622,7 +2622,7 @@ class FeaturePreprocessor:
         if len(df_filtered) == 0:
             raise ValueError("There are no responses left after "
                              "filtering out non-numeric feature values. No analysis "
-                             "will be run")
+                             "will be run.")
 
         df_features = df_filtered.copy()
         df_features_preprocess = df_features.copy()

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -48,7 +48,7 @@ def fast_predict(
     as much as possible.
 
     This function should only be used when the goal is to generate predictions
-    using RSMTool models in production. The user should everything from disk
+    using RSMTool models in production. The user should read everything from disk
     in a separate thread/function and pass the inputs to this function.
 
     Parameters
@@ -94,10 +94,10 @@ def fast_predict(
 
     Returns
     -------
-    pandas DataFrame
-        A dataframe containing the raw, scaled, trimmed, and rounded
+    dict[str, float]
+        A dictionary containing the raw, scaled, trimmed, and rounded
         predictions for the input features. It contains the following
-        columns: "raw", "scale", "raw_trim", "scale_trim", "raw_trim_round",
+        keys: "raw", "scale", "raw_trim", "scale_trim", "raw_trim_round",
         and "scale_trim_round".
 
     Raises
@@ -169,8 +169,8 @@ def fast_predict(
         trim_tolerance,
     )
 
-    # return the predictions without the ID column
-    return df_predictions.drop("spkitemid", axis="columns")
+    # return the predictions as a dictionary but without the ID column
+    return df_predictions.drop("spkitemid", axis="columns").to_dict(orient="records")[0]
 
 
 def compute_and_save_predictions(config_file_or_obj_or_dict,

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -99,7 +99,15 @@ def fast_predict(
         predictions for the input features. It contains the following
         columns: "raw", "scale", "raw_trim", "scale_trim", "raw_trim_round",
         and "scale_trim_round".
+
+    Raises
+    ------
+    ValueError
+        If ``input_features`` contains any non-numeric features.
     """
+    # initialize a logger if none provided
+    logger = logger if logger else logging.getLogger(__name__)
+
     # instantiate a feature preprocessor
     preprocessor = FeaturePreprocessor(logger=logger)
 
@@ -108,7 +116,12 @@ def fast_predict(
     df_input_features["spkitemid"] = "RESPONSE"
 
     # preprocess the input features so that they match what the model expects
-    df_processed_features, _ = preprocessor.preprocess_new_data(df_input_features, df_feature_info)
+    try:
+        df_processed_features, _ = preprocessor.preprocess_new_data(
+            df_input_features, df_feature_info
+        )
+    except ValueError:
+        raise ValueError("Input features must not contain non-numeric values.") from None
 
     # read the post-processing parameters
     trim_min = df_postprocessing_params["trim_min"].values[0]

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -169,9 +169,12 @@ def fast_predict(
             (df_predictions["raw"] - train_predictions_mean) / train_predictions_sd
         ) * h1_sd + h1_mean
 
+    # drop the spkitemid column since it's not needed from this point onwards
+    df_predictions.drop("spkitemid", axis="columns", inplace=True)
+
     # trim both raw and scale predictions if ``trim_min`` and ``trim_max`` were specified
     if trim_min and trim_max:
-        for column in df_predictions.columns.drop("spkitemid"):
+        for column in df_predictions.columns:
             df_predictions[f"{column}_trim"] = preprocessor.trim(
                 df_predictions[column], trim_min, trim_max, trim_tolerance
             )
@@ -179,8 +182,8 @@ def fast_predict(
                 df_predictions[f"{column}_trim"]
             ).astype("int64")
 
-    # return the predictions as a dictionary but without the ID column
-    return df_predictions.drop("spkitemid", axis="columns").to_dict(orient="records")[0]
+    # return the predictions as a dictionary
+    return df_predictions.to_dict(orient="records")[0]
 
 
 def compute_and_save_predictions(config_file_or_obj_or_dict,

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -1094,7 +1094,7 @@ def check_scaled_coefficients(output_dir, experiment_id, file_format='csv'):
     file_format : str, optional
         The format of the output files.
         Defaults to "csv".
-        """
+    """
     preprocessed_test_file = join(output_dir,
                                   '{}_test_preprocessed_features.{}'.format(experiment_id,
                                                                             file_format))
@@ -1120,9 +1120,7 @@ def check_scaled_coefficients(output_dir, experiment_id, file_format='csv'):
     modeler = Modeler.load_from_learner(learner)
 
     # generate new predictions and rename the prediction column to 'scale'
-    df_new_predictions = modeler.predict(df_preprocessed_test_data,
-                                         postproc_params['trim_min'],
-                                         postproc_params['trim_max'])
+    df_new_predictions = modeler.predict(df_preprocessed_test_data)
     df_new_predictions.rename(columns={'raw': 'scale'}, inplace=True)
 
     # check that new predictions match the scaled old predictions

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -328,7 +328,7 @@ def test_run_experiment_predict_expected_scores_non_probablistic_svc():
 
 
 def check_fast_predict(source, do_trim=False, do_scale=False):
-    """Ensure that predictions from `fast_predict()` match expected preditions."""
+    """Ensure that predictions from `fast_predict()` match expected predictions."""
     # define the paths to the various files we need
     test_file = join(rsmtool_test_dir, "data", "files", "test.csv")
     existing_experiment_dir = join(rsmtool_test_dir,
@@ -428,7 +428,7 @@ def test_fast_predict_non_numeric():
     # read in the files
     df_feature_info = pd.read_csv(feature_info_file, index_col=0)
 
-    # initialize the modelr instance
+    # initialize the modeler instance
     modeler = Modeler.load_from_file(model_file)
 
     # input features with non-numeric value

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -349,15 +349,15 @@ def check_fast_predict(source):
     modeler = Modeler.load_from_file(model_file)
 
     # initialize a variable to hold all the predictions
-    prediction_dfs = []
+    prediction_dicts = []
     for input_features in df_test.to_dict(orient="records"):
-        df_predictions = fast_predict(
+        predictions = fast_predict(
             input_features, modeler, df_feature_info, df_postprocessing_params
         )
-        prediction_dfs.append(df_predictions)
+        prediction_dicts.append(predictions)
 
-    # combine all the computed predictions
-    df_computed_predictions = pd.concat(prediction_dfs).reset_index(drop=True)
+    # combine all the computed predictions into a data frame
+    df_computed_predictions = pd.DataFrame(prediction_dicts)
 
     # read in the expected predictions
     df_expected_predictions = pd.read_csv(

--- a/tests/test_modeler.py
+++ b/tests/test_modeler.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 from nose.tools import eq_
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_raises_regex
+
 from rsmtool.modeler import Modeler
 
 
@@ -37,3 +38,10 @@ class TestModeler:
     def test_get_feature_names_is_none(self):
         modeler = Modeler()
         eq_(modeler.get_feature_names(), None)
+
+    def test_expected_scores_no_min_max(self):
+        df = pd.DataFrame([{"spkitemid": "DUMMY", "A": 1, "B": 2}])
+        with assert_raises_regex(
+            ValueError, r"Must specify 'min_score' and 'max_score' for expected scores."
+        ):
+            self.modeler.predict(df, predict_expected=True)


### PR DESCRIPTION
Closes #546. 

The current method that `rsmpredict` uses is called `compute_and_save_prediction()` and is meant for batch prediction – it reads files from disks, does a lot of validation, and writes the predictions to disk. Therefore, it is not suited for real-time prediction on single instances which needs to happen in memory. 

This PR adds a new function called `fast_predict()` to `rsmpredict.py` meant to run on a single data point rather than a batch. This function expects the user to have already read all of the necessary files from disk (e.g., in a RFS service's `setup()` function) and simply pass the in-memory data structures to this function. This function then pre-processes the features, generates predictions for the single data point using the model, and then post-processes the predictions. 

In addition to adding this new function, this PR also adds tests for it and updates the API documentation to include this new function. 