### PR TITLE
Release v9.1.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include requirements.txt
 recursive-include rsmtool/notebooks *
 prune rsmtool/notebooks/.ipynb_checkpoints
 prune rsmtool/notebooks/comparison/.ipynb_checkpoints

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Rater Scoring Modeling Tool
    :target: https://anaconda.org/ets/rsmtool
    :alt: Conda package for SKLL
 
-.. image:: https://img.shields.io/readthedocs/rsmtool/v9.0.1.svg
+.. image:: https://img.shields.io/readthedocs/rsmtool/v9.1.1.svg
    :target: https://rsmtool.readthedocs.io
    :alt: Docs
 

--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rsmtool
-  version: 9.0.1
+  version: 9.1.1
 
 source:
   path: ../../../rsmtool
@@ -36,7 +36,7 @@ requirements:
     - openpyxl
     - pandas
     - seaborn
-    - skll==3.1.0
+    - skll==3.2.0
     - statsmodels
     - tqdm
     - xlrd

--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -32,17 +32,17 @@ This process is only meant for the project administrators, not users and develop
 
    - Update the README and this release documentation, if necessary. Make sure to update the documentation badge in the README to use the latest release tag. That documentation version will be created in the steps below.
 
-#. Build the PyPI source and wheel distributions using ``python setup.py sdist build`` and ``python setup.py bdist_wheel build`` respectively.
+#. Build the PyPI source and wheel distributions using ``python setup.py sdist build`` and ``python setup.py bdist_wheel build`` respectively. Note that you should delete the ``build`` directory after running the ``sdist`` command and before running the ``bdist_wheel`` command.
 
 #. Upload the source and wheel distributions to TestPyPI using ``twine upload --repository testpypi dist/*``. You will need to have the ``twine`` package installed and set up your ``$HOME/.pypirc`` correctly. See details `here <https://packaging.python.org/guides/using-testpypi/>`__. You will need to have the appropriate permissions for the ``ets`` organization on TestPyPI.
 
 #. Install the TestPyPI package as follows::
 
-    pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rsmtool
+    pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rsmtool "pandas>=1.5" "numpy>=1.24" "matplotlib>=3.6" "jupyter_server>=2.0" "notebook-shim>=0.2.0"
 
 #. Then run some tests from a RSMTool working copy. If the TestPyPI package works, then move on to the next step. If it doesn't, figure out why and rebuild and re-upload the package.
 
-#. Build the new conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool``). Note that you may need to comment out lines in your `$HOME/.condarc` file if you are using ETS Artifactory and you get conflicts::
+#. Build the new conda package by running the following command in the ``conda-recipe`` directory (note that this assumes that you have cloned RSMTool in a directory named ``rsmtool``). You should delete the ``build`` directory before running the command below. Note that you may need to comment out lines in your `$HOME/.condarc` file if you are using ETS Artifactory and you get conflicts::
 
     conda build -c conda-forge -c ets .
 

--- a/rsmtool/version.py
+++ b/rsmtool/version.py
@@ -5,5 +5,5 @@ This module exists solely for version information so we only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 """
 
-__version__ = "9.0.1"
+__version__ = "9.1.1"
 VERSION = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
This release PR for v9.1.1 makes the following changes:

- Update version number. 
- Update conda recipe to use the latest release of SKLL. 
- Update release documentation to use the latest pip constraints and instructions for creating PyPI packages. 
- Update `MANIFEST.in` to include `requirements.txt` in the PyPI package which is required now. 

**Note**: I had to use v9.1.1 because the TestPyPI package for v9.1.0 failed (due to missing `requirements.txt`) and TestPyPI doesn't let you reuse version numbers once they have been uploaded. I figured 9.1.1 was better than something like 9.1.0.post1, which is what they recommend. 

The conda and TestPyPI packages were built and uploaded. Both pass tests as shown in these PRs:
- [conda](https://github.com/EducationalTestingService/rsmtool-conda-tester/pull/18)
- [TestPyPI](https://github.com/EducationalTestingService/rsmtool-pip-tester/pull/15)

As always, please test both the conda and TestPyPI package locally on either Linux or macOS by installing them and trying to run some small tests or one of the examples. 
- To install the conda package, run `mamba create -n rsmtest -c ets -c conda-forge python=3.9 rsmtool`. You can choose to use Python 3.8, 3.9, or 3.10. 
- To install the TestPyPI package, create a conda environment with either Python 3.8, 3.9, or 3.10 first and then run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rsmtool "pandas>=1.5" "numpy>=1.24" "matplotlib>=3.6" "jupyter_server>=2.0" "notebook-shim>=0.2.0"`. 
