### PR TITLE
Use example IDs when specifying `sample_ids`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *test_outputs/
 
 __pycache__
+junit.xml

--- a/doc/config_rsmexplain.rst.inc
+++ b/doc/config_rsmexplain.rst.inc
@@ -65,7 +65,7 @@ If we want to explain a random sample of the responses in explain_data, we can s
 
 sample_ids *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~
-If we want to explain a specific set of responses from the ``explain_data``, we can specify their IDs here as a comma-separated string (no whitespace). Note that the IDs must be values from the :ref:`id_column <rsmexplain_id_column>`. For example, if ``explain_data`` has IDs of the form ``"EXAMPLE_1"``, ``"EXAMPLE_2"`` etc. and we want to explain the fifth, tenth, and twelfth example, the value of this field must be set to ``"EXAMPLE_5,EXAMPLE_10,EXAMPLE_12"``. Defaults to ``None``.
+If we want to explain a specific set of responses from the ``explain_data``, we can specify their IDs here as a comma-separated string. Note that the IDs must be values from the :ref:`id_column <rsmexplain_id_column>`. For example, if ``explain_data`` has IDs of the form ``"EXAMPLE_1"``, ``"EXAMPLE_2"`` etc. and we want to explain the fifth, tenth, and twelfth example, the value of this field must be set to ``"EXAMPLE_5, EXAMPLE_10, EXAMPLE_12"``. Defaults to ``None``.
 
 .. note ::
 

--- a/doc/config_rsmexplain.rst.inc
+++ b/doc/config_rsmexplain.rst.inc
@@ -43,15 +43,11 @@ num_features_to_display *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Number of top features that should be displayed in ``rsmexplain`` plots. Defaults to 15.
 
+.. _rsmexplain_id_column:
+
 id_column *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~
-The name of the column containing the response IDs. Defaults to ``spkitemid``, i.e., if this is not specified, ``rsmexplain`` will look for a column called ``spkitemid`` in both background_data and explain_data files. Note: id_column must be the same in these two files.
-
-.. _rsmexplain_sample_ids:
-
-sample_ids *(Optional)*
-~~~~~~~~~~~~~~~~~~~~~~~
-If we want to explain a specific set of responses from the ``explain_data``, we can specify them here. Note that the ids are specified in terms of the location of the responses in the explain_data file and that the locations are zero-indexed. So, for example, to explain only the first, third and tenth responses in the file, we should set a value of "0,2,9" for this option. Defaults to ``None``.
+The name of the column containing the response IDs. Defaults to ``spkitemid``, i.e., if this is not specified, ``rsmexplain`` will look for a column called ``spkitemid`` in both ``background_data`` and ``explain_data`` files. Note that the name of the ``id_column`` must be the same in these two files.
 
 .. _rsmexplain_sample_range:
 
@@ -63,11 +59,17 @@ If we want to explain a specific range of responses from the ``explain_data``, w
 
 sample_size *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~~
-If we want to explain a random sample of the responses in explain_data, we can specify the size of that random sample here. For example, to explain a random sample of 10 responses, we would set this to 10. Defaults to None.
+If we want to explain a random sample of the responses in explain_data, we can specify the size of that random sample here. For example, to explain a random sample of 10 responses, we would set this to 10. Defaults to ``None``.
+
+.. _rsmexplain_sample_ids:
+
+sample_ids *(Optional)*
+~~~~~~~~~~~~~~~~~~~~~~~
+If we want to explain a specific set of responses from the ``explain_data``, we can specify their IDs here as a comma-separated string (no whitespace). Note that the IDs must be values from the :ref:`id_column <rsmexplain_id_column>`. For example, if ``explain_data`` has IDs of the form ``"EXAMPLE_1"``, ``"EXAMPLE_2"`` etc. and we want to explain the fifth, tenth, and twelfth example, the value of this field must be set to ``"EXAMPLE_5,EXAMPLE_10,EXAMPLE_12"``. Defaults to ``None``.
 
 .. note ::
 
-    Only one of ``sample_ids``, ``sample_range`` or ``sample_size`` must be specified. If neither is specified, explanations will be generated for the entire set of responses in ``explain_data`` which could be very slow, depending on its size.
+    Only one of ``sample_ids``, ``sample_range`` or ``sample_size`` must be specified. If none of them are specified, explanations will be generated for the entire set of responses in ``explain_data`` which could be very slow, depending on its size.
 
 show_auto_cohorts *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rsmtool/rsmexplain.py
+++ b/rsmtool/rsmexplain.py
@@ -60,11 +60,14 @@ def select_examples(featureset, range_size=None):
     elif isinstance(range_size, int):
         selected_ids = shap.sample(fs_ids, range_size)
     elif isinstance(range_size, tuple):
-        selected_ids = range_size
+        selected_ids = np.array(range_size)
     else:
         start, end = range_size
         # NOTE: include the end index in the selected examples since it's more intuitive
         selected_ids = fs_ids[start : end + 1]  # noqa: E203
+
+    # make sure that ``selected_ids`` is the same data type as ``fs_ids``
+    selected_ids = selected_ids.astype(fs_ids.dtype)
 
     # find the positions of the selected ids in the original featureset
     try:

--- a/rsmtool/rsmexplain.py
+++ b/rsmtool/rsmexplain.py
@@ -347,7 +347,8 @@ def generate_explanation(
     elif has_sample_range:
         range_size = parse_range(configuration.get("sample_range"))
     elif has_sample_ids:
-        range_size = tuple(configuration.get("sample_ids").split(","))
+        range_size = configuration.get("sample_ids").split(",")
+        range_size = tuple([id_.strip() for id_ in range_size])
     else:
         range_size = None
         logger.warning(

--- a/tests/test_experiment_rsmexplain.py
+++ b/tests/test_experiment_rsmexplain.py
@@ -79,7 +79,7 @@ class TestExperimentRsmexplain(unittest.TestCase):
             "background_kmeans_size": 50,
             "explain_data": new_file_dict["explain_data"],
             "id_column": "ID",
-            "sample_ids": "5, 10, 20",
+            "sample_ids": "RESPONSE_6, RESPONSE_11, RESPONSE_21",
             "num_features_to_display": 15,
             "show_auto_cohorts": True,
         }

--- a/tests/test_explanation_utils.py
+++ b/tests/test_explanation_utils.py
@@ -39,13 +39,13 @@ class TestExplainUtils(unittest.TestCase):
         X_train, y_train = X[:train_size], y[:train_size]
         X_test = X[train_size:]
 
-        train_ids = list(range(1, train_size + 1))
+        train_ids = [f"TRAIN_{idx}" for idx in range(1, train_size + 1)]
         train_features = [
             dict(zip([f"FEATURE_{i + 1}" for i in range(num_features)], x)) for x in X_train
         ]
         train_labels = list(y_train)
 
-        test_ids = list(range(1, test_size + 1))
+        test_ids = [f"TEST_{idx}" for idx in range(1, test_size + 1)]
         test_features = [
             dict(zip([f"FEATURE_{i + 1}" for i in range(num_features)], x)) for x in X_test
         ]
@@ -63,84 +63,111 @@ class TestExplainUtils(unittest.TestCase):
     def test_select_features_empty_range_size(self):
         """Test select_features with no user-specified range or size."""
         expected_output = {
-            0: 1,
-            1: 2,
-            2: 3,
-            3: 4,
-            4: 5,
-            5: 6,
-            6: 7,
-            7: 8,
-            8: 9,
-            9: 10,
-            10: 11,
-            11: 12,
-            12: 13,
-            13: 14,
-            14: 15,
+            0: "TEST_1",
+            1: "TEST_2",
+            2: "TEST_3",
+            3: "TEST_4",
+            4: "TEST_5",
+            5: "TEST_6",
+            6: "TEST_7",
+            7: "TEST_8",
+            8: "TEST_9",
+            9: "TEST_10",
+            10: "TEST_11",
+            11: "TEST_12",
+            12: "TEST_13",
+            13: "TEST_14",
+            14: "TEST_15",
         }
         self.assertEqual(select_examples(self.test_fs), expected_output)
 
     def test_select_features_integer_range_size(self):
         """Test select_features with an integer range size."""
-        expected_output = {1: 2, 6: 7}
+        expected_output = {1: "TEST_2", 6: "TEST_7"}
         self.assertEqual(select_examples(self.test_fs, range_size=2), expected_output)
 
     def test_select_features_integer_exceed_range_size(self):
         """Test select_features with range size larger than data size."""
         expected_output = {
-            0: 1,
-            1: 2,
-            2: 3,
-            3: 4,
-            4: 5,
-            5: 6,
-            6: 7,
-            7: 8,
-            8: 9,
-            9: 10,
-            10: 11,
-            11: 12,
-            12: 13,
-            13: 14,
-            14: 15,
+            0: "TEST_1",
+            1: "TEST_2",
+            2: "TEST_3",
+            3: "TEST_4",
+            4: "TEST_5",
+            5: "TEST_6",
+            6: "TEST_7",
+            7: "TEST_8",
+            8: "TEST_9",
+            9: "TEST_10",
+            10: "TEST_11",
+            11: "TEST_12",
+            12: "TEST_13",
+            13: "TEST_14",
+            14: "TEST_15",
         }
         self.assertEqual(select_examples(self.test_fs, range_size=20), expected_output)
 
     def test_select_features_full_range_size(self):
         """Test select_features with an iterable range size."""
-        expected_output = {5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11}
+        expected_output = {
+            5: "TEST_6",
+            6: "TEST_7",
+            7: "TEST_8",
+            8: "TEST_9",
+            9: "TEST_10",
+            10: "TEST_11",
+        }
         self.assertEqual(select_examples(self.test_fs, range_size=[5, 10]), expected_output)
 
     def test_select_features_exceed_range_size(self):
         """Test select_features with range size larger than data size."""
-        expected_output = {10: 11, 11: 12, 12: 13, 13: 14, 14: 15}
+        expected_output = {
+            10: "TEST_11",
+            11: "TEST_12",
+            12: "TEST_13",
+            13: "TEST_14",
+            14: "TEST_15",
+        }
         self.assertEqual(select_examples(self.test_fs, range_size=[10, 20]), expected_output)
 
     def test_select_features_range_ids_size(self):
         """Test select_features with specific example IDs."""
-        expected_output = {5: 6, 10: 11, 12: 13}
-        self.assertEqual(select_examples(self.test_fs, range_size=(5, 10, 12)), expected_output)
+        expected_output = {4: "TEST_5", 9: "TEST_10", 11: "TEST_12"}
+        self.assertEqual(
+            select_examples(self.test_fs, range_size=("TEST_5", "TEST_10", "TEST_12")),
+            expected_output,
+        )
 
     def test_select_features_inordered_range_ids_size(self):
         """Test select_features with unordered range ids."""
-        expected_output = {
-            10: 11,
-            1: 2,
-            5: 6,
-        }
-        self.assertEqual(select_examples(self.test_fs, range_size=(1, 5, 10)), expected_output)
+        expected_output = {11: "TEST_12", 4: "TEST_5", 9: "TEST_10"}
+        self.assertEqual(
+            select_examples(self.test_fs, range_size=("TEST_12", "TEST_5", "TEST_10")),
+            expected_output,
+        )
 
     def test_select_features_exceed_range_ids_size(self):
         """Test select_features with out of boundary range ids."""
-        with self.assertRaises(IndexError):
-            select_examples(self.test_fs, range_size=(1, 5, 20))
+        with self.assertRaises(ValueError):
+            select_examples(self.test_fs, range_size=("TEST_5", "TEST_10", "TEST_20"))
+
+    def test_select_features_invalid_range_ids_size(self):
+        """Test select_features with invalid range ids."""
+        with self.assertRaises(ValueError):
+            select_examples(self.test_fs, range_size=("1", "5", "10"))
 
     def test_mask_from_learner_in_memory(self):
         """Test mask with a SKLL Learner created in memory."""
         output_path = join(rsmtool_test_dir, "data", "output", "explain_mask_from_learner.out")
         expected_features = np.loadtxt(output_path)
-        expected_ids = {5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11}
+        expected_ids = {
+            5: "TEST_6",
+            6: "TEST_7",
+            7: "TEST_8",
+            8: "TEST_9",
+            9: "TEST_10",
+            10: "TEST_11",
+        }
         computed_ids, computed_features = mask(self.svc, self.test_fs, feature_range=[5, 10])
         self.assertEqual(computed_ids, expected_ids)
         assert_array_almost_equal(computed_features, expected_features)

--- a/tests/test_explanation_utils.py
+++ b/tests/test_explanation_utils.py
@@ -45,7 +45,8 @@ class TestExplainUtils(unittest.TestCase):
         ]
         train_labels = list(y_train)
 
-        test_ids = [f"TEST_{idx}" for idx in range(1, test_size + 1)]
+        test_ids_strings = [f"TEST_{idx}" for idx in range(1, test_size + 1)]
+        test_ids_ints = list(range(1, test_size + 1))
         test_features = [
             dict(zip([f"FEATURE_{i + 1}" for i in range(num_features)], x)) for x in X_test
         ]
@@ -53,7 +54,8 @@ class TestExplainUtils(unittest.TestCase):
         cls.train_fs = FeatureSet(
             "train", ids=train_ids, features=train_features, labels=train_labels
         )
-        cls.test_fs = FeatureSet("test", ids=test_ids, features=test_features)
+        cls.test_fs = FeatureSet("test", ids=test_ids_strings, features=test_features)
+        cls.test_fs_int_ids = FeatureSet("test", ids=test_ids_ints, features=test_features)
 
         # create a dummy learner
         svc = Learner("SVC")
@@ -143,6 +145,14 @@ class TestExplainUtils(unittest.TestCase):
         expected_output = {11: "TEST_12", 4: "TEST_5", 9: "TEST_10"}
         self.assertEqual(
             select_examples(self.test_fs, range_size=("TEST_12", "TEST_5", "TEST_10")),
+            expected_output,
+        )
+
+    def test_select_features_mismatched_range_ids_size(self):
+        """Test select_features with range IDs as strings but featureset IDs as ints."""
+        expected_output = {4: 5, 9: 10, 11: 12}
+        self.assertEqual(
+            select_examples(self.test_fs_int_ids, range_size=("5", "10", "12")),
             expected_output,
         )
 


### PR DESCRIPTION
- Assume that `sample_ids` are now actual example IDs instead of indices.
- Raise a `ValueError` if anything goes wrong in `select_examples`.
- Update `test_explanation_utils.py`    
  - Use actual string IDs in the test data.
  - Update all expected outputs to use these new string IDs.
- Update relevant test in `test_experiment_rsmexplain.py` to IDs. 
- Update rsmexplain documentation
  - Update description of `sample_ids` and move it to the end.
  - Fix some typos.

Closes #609. 
