### PR TITLE
Remove unnecessary warnings in HTML reports.

### DIFF
--- a/rsmtool/fairness_utils.py
+++ b/rsmtool/fairness_utils.py
@@ -261,10 +261,9 @@ def get_fairness_analyses(
     # we filter warnings for this function because we get
     # runtime warning due to NaNs in the data.
     # these seem to be by design: https://groups.google.com/forum/#!topic/pystatsmodels/-flY0cNnb3k
-    warnings.filterwarnings("ignore")
-    anova_results = anova_lm(csd_null_fit, csd_fit)
-    # we reset warnings
-    warnings.resetwarnings()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        anova_results = anova_lm(csd_null_fit, csd_fit)
 
     # collect the results. Note that R2 in this case is a difference
     # in R2 between the two models and significance is obtained from anova

--- a/rsmtool/notebooks/comparison/header.ipynb
+++ b/rsmtool/notebooks/comparison/header.ipynb
@@ -15,10 +15,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Comparison Report "
+    "## filter out warnings from third-party libraries to prevent them\n",
+    "# from showing up in the notebooks in multiple places\n",
+    "import warnings\n",
+    "\n",
+    "# warning from shap about tqdm \n",
+    "from tqdm import TqdmExperimentalWarning\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=TqdmExperimentalWarning, \n",
+    "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
+    "                        module=\"shap.explainers._linear\")\n",
+    "\n",
+    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=UserWarning, \n",
+    "                        message=\".*figure layout.*\", \n",
+    "                        module=\"seaborn.axisgrid\")\n"
    ]
   },
   {
@@ -181,6 +198,13 @@
     "\n",
     "if len(groups_eval) == 1 and groups_eval[0] == '':\n",
     "    groups_eval = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparison Report "
    ]
   },
   {

--- a/rsmtool/notebooks/explanations/header.ipynb
+++ b/rsmtool/notebooks/explanations/header.ipynb
@@ -14,11 +14,28 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "8d298191",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33871499-04f1-4fc7-8d4b-48c0bfb97546",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Explanation Report"
+    "## filter out warnings from third-party libraries to prevent them\n",
+    "# from showing up in the notebooks in multiple places\n",
+    "import warnings\n",
+    "\n",
+    "# warning from shap about tqdm \n",
+    "from tqdm import TqdmExperimentalWarning\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=TqdmExperimentalWarning, \n",
+    "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
+    "                        module=\"shap.explainers._linear\")\n",
+    "\n",
+    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=UserWarning, \n",
+    "                        message=\".*figure layout.*\", \n",
+    "                        module=\"seaborn.axisgrid\")"
    ]
   },
   {
@@ -161,6 +178,14 @@
     "\n",
     "# javascript path\n",
     "javascript_path = environ_config.get(\"JAVASCRIPT_PATH\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d298191",
+   "metadata": {},
+   "source": [
+    "# Explanation Report"
    ]
   },
   {

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -13,10 +13,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Experiment Report "
+    "## filter out warnings from third-party libraries to prevent them\n",
+    "# from showing up in the notebooks in multiple places\n",
+    "import warnings\n",
+    "\n",
+    "# warning from shap about tqdm \n",
+    "from tqdm import TqdmExperimentalWarning\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=TqdmExperimentalWarning, \n",
+    "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
+    "                        module=\"shap.explainers._linear\")\n",
+    "\n",
+    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=UserWarning, \n",
+    "                        message=\".*figure layout.*\", \n",
+    "                        module=\"seaborn.axisgrid\")\n"
    ]
   },
   {
@@ -32,7 +49,6 @@
     "import pickle\n",
     "import platform\n",
     "import time\n",
-    "import warnings\n",
     "\n",
     "from functools import partial\n",
     "from os.path import abspath, relpath, exists, join\n",
@@ -187,6 +203,13 @@
     "\n",
     "# javascript path\n",
     "javascript_path = environ_config.get(\"JAVASCRIPT_PATH\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Experiment Report "
    ]
   },
   {

--- a/rsmtool/notebooks/summary/header.ipynb
+++ b/rsmtool/notebooks/summary/header.ipynb
@@ -15,10 +15,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Summary Report "
+    "## filter out warnings from third-party libraries to prevent them\n",
+    "# from showing up in the notebooks in multiple places\n",
+    "import warnings\n",
+    "\n",
+    "# warning from shap about tqdm \n",
+    "from tqdm import TqdmExperimentalWarning\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=TqdmExperimentalWarning, \n",
+    "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
+    "                        module=\"shap.explainers._linear\")\n",
+    "\n",
+    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
+    "warnings.filterwarnings(\"ignore\", \n",
+    "                        category=UserWarning, \n",
+    "                        message=\".*figure layout.*\", \n",
+    "                        module=\"seaborn.axisgrid\")"
    ]
   },
   {
@@ -154,6 +171,13 @@
     "\n",
     "# javascript path\n",
     "javascript_path = environ_config.get(\"JAVASCRIPT_PATH\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Summary Report "
    ]
   },
   {


### PR DESCRIPTION
- Update the header notebooks for all tools to exclude the matplotlib and tqdm warnings that were being shown in all the reports.
- Replace unnecessary use of `resetwarnings()` with the `catch_warnings()` context manager in `fairness_utils.py`.  This is necessary to ensure that the filtering of warnings in notebooks works as expected.

To test this, please check out the branch, run an experiments for each of the command-line tools, and confirm that no warnings are shown in the reports.

This PR closes #618. 