### PR TITLE
Suppress alt text warnings when generating reports

### DIFF
--- a/doc/config_rsmexplain.rst.inc
+++ b/doc/config_rsmexplain.rst.inc
@@ -65,7 +65,7 @@ Number of top features that should be displayed in ``rsmexplain`` plots. Default
 
 sample_ids *(Optional)*
 ~~~~~~~~~~~~~~~~~~~~~~~
-If we want to explain a specific set of responses from the ``explain_data``, we can specify their IDs here as a comma-separated string. Note that the IDs must be values from the :ref:`id_column <rsmexplain_id_column>`. For example, if ``explain_data`` has IDs of the form ``"EXAMPLE_1"``, ``"EXAMPLE_2"`` etc. and we want to explain the fifth, tenth, and twelfth example, the value of this field must be set to ``"EXAMPLE_5, EXAMPLE_10, EXAMPLE_12"``. Defaults to ``None``.
+If we want to explain a specific set of responses from the ``explain_data``, we can specify their IDs here as a comma-separated string. Note that the IDs must be values from the :ref:`id_column <rsmexplain_id_column>`. For example, if ``explain_data`` has IDs of the form ``"EXAMPLE_1"``, ``"EXAMPLE_2"``, etc., and we want to explain the fifth, tenth, and twelfth example, the value of this field must be set to ``"EXAMPLE_5, EXAMPLE_10, EXAMPLE_12"``. Defaults to ``None``.
 
 .. _rsmexplain_sample_range:
 

--- a/rsmtool/notebooks/explanations/shap_values.ipynb
+++ b/rsmtool/notebooks/explanations/shap_values.ipynb
@@ -194,7 +194,7 @@
     "\n",
     "Features in the table below are the ones with the largest impact according to the maximum absolute SHAP value. If these *do not* overlap with the features with the largest mean impact, then it is likely that they have large outlier values, but lower average impact. \n",
     "\n",
-    "*Note: if your model has less than or equal to 5 features, all of them will be displayed. *"
+    "*Note: if your model has less than or equal to 5 features, all of them will be displayed.*"
    ]
   },
   {

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -400,8 +400,16 @@ class Reporter:
 
         default_filters["clean_html"] = custom_clean_html
 
+        # we want to suppress the logged warning from nbconvert about missing
+        # alt text since there is currently no easy way to add alt text to
+        # inlined-SVG images that are generated programmatically. To do this,
+        # we will temporarily change the log level for the log object that
+        # produces this warning and then restore it after we are done
         exportHtml = HTMLExporter(config=report_config)
+        old_level = exportHtml.log.level
+        exportHtml.log.setLevel(logging.ERROR)
         output, _ = exportHtml.from_filename(notebook_file)
+        exportHtml.log.setLevel(old_level)
         open(html_file, mode="w", encoding="utf-8").write(output)
 
     def determine_chosen_sections(


### PR DESCRIPTION
Temporarily change the log level of the `HTMLExporter` instance to suppress the warning of the type "WARNING: Alternative text missing on XX image(s)". 

To test, run all of the tutorials and make sure that there are no warnings of the above type printed out on the terminal. 

Closes #626. 