### PR TITLE
Fix W&B tests and add to CI builds.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,7 @@ source=rsmtool
 parallel=true
 omit =
     *rsmtool/notebooks/templates/report.tpl
+    setup.py
+    sitecustomize.py
+    examples/*
+    tests/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ testset1:
 testset2:
   extends: ".runtests"
   variables:
-    TESTFILES: "test_comparer test_configuration_parser test_experiment_rsmtool_2"
+    TESTFILES: "test_comparer test_configuration_parser test_experiment_rsmtool_2 test_wandb"
   stage: "test"
 
 # third set of test files

--- a/DistributeTests.ps1
+++ b/DistributeTests.ps1
@@ -36,6 +36,7 @@ elseif ($agentNumber -eq 2) {
     $testsToRun = $testsToRun + "test_configuration_parser"
     $testsToRun = $testsToRun + "test_experiment_rsmtool_2"
     $testsToRun = $testsToRun + "test_container"
+    $testsToRun = $testsToRun + "test_wandb"
 }
 elseif ($agentNumber -eq 3) {
     $testsToRun = $testsToRun + "test_analyzer"


### PR DESCRIPTION
- Fix broken `wandb` test.
- Add missing `test_wandb` to both CI builds. 
- Remove non-code files from coverage computation by fixing `.coveragerc`. 

Closes #635. 