### PR TITLE
Switch to `ruff` for pre-commit checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source=rsmtool
 parallel=true
 omit =
     *rsmtool/notebooks/templates/report.tpl
+    rsmtool/test_utils.py
     setup.py
     sitecustomize.py
     examples/*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-use_parentheses = true
-ensure_newline_before_comments = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,28 +10,22 @@ repos:
         exclude: .(tsv|csv|json)$
       - id: check-ast
       - id: debug-statements
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: 'v2.3.0'
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
   - repo: https://github.com/ikamensh/flynt/
-    rev: '0.78'
+    rev: '1.0.1'
     hooks:
       - id: flynt
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         args: [--line-length=100]
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.281'
     hooks:
-      - id: flake8
-        args: [--max-line-length=100, '--per-file-ignores=tests/update_files.py:E501']
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        additional_dependencies: ["toml"]
-        exclude: 'setup.py|rsmtool/utils/__init__.py'
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files", "--multi-line", "3", "--trailing-comma", "--use-parentheses", "--ensure-newline-before-comments"]
+      - id: ruff
+        args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D100,tests/test*.py:D101,tests/test*.py:D102,tests/test*.py:D103"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,10 @@
+select = ["D", "E", "F", "I"]
+ignore = ["D212"]
+line-length = 100
+target-version = "py38"
+
+[pydocstyle]
+convention = "numpy"
+
+[per-file-ignores]
+"tests/test*.py" = ["D100", "D101", "D102", "D103"]

--- a/rsmtool/modeler.py
+++ b/rsmtool/modeler.py
@@ -1181,7 +1181,7 @@ class Modeler:
         data and save the results in the given directories using the
         given experiment ID as the prefix.
 
-        parameters
+        Parameters
         ----------
         configuration : configuration_parser.Configuration
             A configuration object containing "experiment_id" and "model_name"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import argparse
 import filecmp
+import logging
 import unittest
 import warnings
 from io import StringIO
@@ -44,7 +45,7 @@ from rsmtool.utils.files import (
     has_files_with_extension,
     parse_json_with_comments,
 )
-from rsmtool.utils.logging import get_file_logger
+from rsmtool.utils.logging import LogFormatter, get_file_logger
 from rsmtool.utils.metrics import (
     compute_expected_scores_from_model,
     difference_of_standardized_means,
@@ -2015,9 +2016,7 @@ class TestInteractiveField(unittest.TestCase):
             )
 
     def check_optional_interactive_fields_blanks(self, field_name, field_count):
-        """
-        Check that blank user input for an optional field is handled correctly
-        """
+        """Check that blank user input for an optional field is handled correctly."""
         default_value = DEFAULTS.get(field_name)
         blank_return_value = "" if field_count == "single" else []
         with patch("rsmtool.utils.commandline.prompt", return_value=blank_return_value):
@@ -2195,8 +2194,7 @@ class TestInteractiveGenerate(unittest.TestCase):
 
     def check_tool_interact(self, context, subgroups=False, with_folds_file=False):
         """
-        A helper method that runs `ConfigurationGenerator.interact()`
-        and compares its output to expected output.
+        Run ``ConfigurationGenerator.interact()`` and validate output.
 
         Parameters
         ----------
@@ -2275,3 +2273,35 @@ class TestInteractiveGenerate(unittest.TestCase):
         yield self.check_tool_interact, "rsmxval", False, True
         yield self.check_tool_interact, "rsmxval", True, False
         yield self.check_tool_interact, "rsmxval", True, True
+
+
+class TestLogFormatter(unittest.TestCase):
+    def test_format_debug(self):
+        formatter = LogFormatter()
+        record = logging.LogRecord(
+            "name", logging.DEBUG, "pathname", 10, "debug message", None, None
+        )
+        formatted = formatter.format(record)
+        self.assertEqual(formatted, "DEBUG: pathname: 10: debug message")
+
+    def test_format_warning(self):
+        formatter = LogFormatter()
+        record = logging.LogRecord(
+            "name", logging.WARNING, "pathname", 10, "warning message", None, None
+        )
+        formatted = formatter.format(record)
+        self.assertEqual(formatted, "WARNING: warning message")
+
+    def test_format_info(self):
+        formatter = LogFormatter()
+        record = logging.LogRecord("name", logging.INFO, "pathname", 10, "info message", None, None)
+        formatted = formatter.format(record)
+        self.assertEqual(formatted, "info message")
+
+    def test_format_error(self):
+        formatter = LogFormatter()
+        record = logging.LogRecord(
+            "name", logging.ERROR, "pathname", 10, "error message", None, None
+        )
+        formatted = formatter.format(record)
+        self.assertEqual(formatted, "ERROR: error message")


### PR DESCRIPTION
- Update pre-commit checks to use `ruff` instead of `flake8`, `isort`, and `pydocstyle`.  
- Add `.ruff.toml` file and remove `.isort.cfg` file. 
- Fix case in one of the docstrings. 
- Update `.coveragerc` to exclude unneeded file.
- Add new unit test to increase coverage. 

Closes #629. 