### PR TITLE
Release/11.0.1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,3 @@ python:
   version: "3.8"
   install:
     - requirements: doc/requirements.txt
-  system_packages: true

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ Requirements
 - ``notebook``
 - ``seaborn``
 - ``shap``==0.42.0
+- ``wandb``
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Rater Scoring Modeling Tool
    :target: https://anaconda.org/ets/rsmtool
    :alt: Conda package for SKLL
 
-.. image:: https://img.shields.io/readthedocs/rsmtool/v10.0.0.svg
+.. image:: https://img.shields.io/readthedocs/rsmtool/v11.0.1.svg
    :target: https://rsmtool.readthedocs.io
    :alt: Docs
 

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Requirements
 - ``jupyter``
 - ``notebook``
 - ``seaborn``
-- ``shap``==0.42.0
+- ``shap==0.42.0``
 - ``wandb``
 
 Contributing

--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -28,20 +28,21 @@ requirements:
     - pip
     - setuptools
   run:
-    - python
-    - jupyter
     - ipython
+    - jupyter
     - notebook
     - numpy
     - openpyxl
     - pandas
+    - python
     - seaborn
+    - shap==0.42.1
     - skll==4.0.0
     - statsmodels
     - tqdm
+    - wandb
     - xlrd
     - xlwt
-    - shap==0.42.1
 
 test:
   # Python imports

--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - ipython
     - jupyter
     - notebook
-    - numpy
+    - numpy<1.25
     - openpyxl
     - pandas
     - python

--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rsmtool
-  version: 10.0.0
+  version: 11.0.1
 
 source:
   path: ../../../rsmtool
@@ -31,7 +31,6 @@ requirements:
     - python
     - jupyter
     - ipython
-    - nose
     - notebook
     - numpy
     - openpyxl

--- a/doc/internal/release_process.rst
+++ b/doc/internal/release_process.rst
@@ -5,7 +5,7 @@ This process is only meant for the project administrators, not users and develop
 
 #. Recreate the development environment so all unpinned packages are updated to their latest versions. See instructions for this `here <https://rsmtool.readthedocs.io/en/main/contributing.html#setting-up>`_.
 
-#. Make sure any and all tests are passing in ``main``. Make sure you have also run tests locally in strict mode (``STRICT=1 nosetests --nologcapture tests``) to catch any warnings in the HTML report that can be fixed before the release.
+#. Make sure any and all tests are passing in ``main``. Make sure you have also run tests locally in strict mode (``STRICT=1 nose2 -s tests``) to catch any warnings in the HTML report that can be fixed before the release.
 
 #. Run the ``tests/update_files.py`` script with the appropriate arguments to make sure that all test data in the new release have correct experiment ids and filenames. If any (non-model) files need to be changed this should be investigated before the branch is released. Please see more details about running this `here <https://rsmtool.readthedocs.io/en/main/contributing.html#writing-new-functional-tests>`__.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ipython
 jupyter
 nose2
 notebook
-numpy
+numpy<1.25
 openpyxl
 pandas
 pre-commit

--- a/rsmtool/version.py
+++ b/rsmtool/version.py
@@ -5,5 +5,5 @@ This module exists solely for version information so we only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 """
 
-__version__ = "10.0.0"
+__version__ = "11.0.1"
 VERSION = tuple(int(x) for x in __version__.split("."))

--- a/tests/data/experiments/linearsvr-self-compare/linearsvr/output/LinearSVR_rsmtool.json
+++ b/tests/data/experiments/linearsvr-self-compare/linearsvr/output/LinearSVR_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/linearsvr-self-summary/linearsvr/output/LinearSVR_rsmtool.json
+++ b/tests/data/experiments/linearsvr-self-summary/linearsvr/output/LinearSVR_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/linearsvr-self-summary/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/linearsvr-self-summary/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-different-compare/lr-subset-features/output/lr_subset_rsmtool.json
+++ b/tests/data/experiments/lr-different-compare/lr-subset-features/output/lr_subset_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-different-compare/lr/output/lr_rsmtool.json
+++ b/tests/data/experiments/lr-different-compare/lr/output/lr_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-eval-self-compare/lr-eval-with-h2/output/lr_eval_with_h2_rsmeval.json
+++ b/tests/data/experiments/lr-eval-self-compare/lr-eval-with-h2/output/lr_eval_with_h2_rsmeval.json
@@ -27,5 +27,8 @@
     "min_n_per_group": null,
     "section_order": null,
     "flag_column": null,
-    "min_items_per_candidate": null
+    "min_items_per_candidate": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-eval-tool-compare/lr-eval-with-h2/output/lr_eval_with_h2_rsmeval.json
+++ b/tests/data/experiments/lr-eval-tool-compare/lr-eval-with-h2/output/lr_eval_with_h2_rsmeval.json
@@ -27,5 +27,8 @@
     "min_n_per_group": null,
     "section_order": null,
     "flag_column": null,
-    "min_items_per_candidate": null
+    "min_items_per_candidate": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-eval-tool-compare/lr-with-h2/output/lr_with_h2_rsmtool.json
+++ b/tests/data/experiments/lr-eval-tool-compare/lr-with-h2/output/lr_with_h2_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-dict/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-dict/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-different-format/lr-with-tsv-output/output/lr_with_tsv_output_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-different-format/lr-with-tsv-output/output/lr_with_tsv_output_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-object/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-object/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-chosen-sections/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-chosen-sections/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-custom-order/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-custom-order/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-custom-sections-and-custom-order/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-custom-sections-and-custom-order/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-h2/lr-with-h2/output/lr_with_h2_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-h2/lr-with-h2/output/lr_with_h2_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-subgroups-and-edge-cases/lr-subgroups-with-edge-cases/output/lr_subgroups_with_edge_cases_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-subgroups-and-edge-cases/lr-subgroups-with-edge-cases/output/lr_subgroups_with_edge_cases_rsmtool.json
@@ -42,6 +42,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-subgroups-and-h2/lr-subgroups-with-h2/output/lr_subgroups_with_h2_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-subgroups-and-h2/lr-subgroups-with-h2/output/lr_subgroups_with_h2_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare-with-thumbnails/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare-with-thumbnails/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-compare/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-compare/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-eval-summary/lr-eval/output/lr_evaluation_rsmeval.json
+++ b/tests/data/experiments/lr-self-eval-summary/lr-eval/output/lr_evaluation_rsmeval.json
@@ -26,5 +26,8 @@
     "min_n_per_group": null,
     "section_order": null,
     "flag_column": null,
-    "min_items_per_candidate": null
+    "min_items_per_candidate": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-eval-summary/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-eval-summary/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-eval-summary/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-eval-summary/output/model_comparison_rsmsummarize.json
@@ -16,5 +16,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-dict/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-dict/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-no-scaling/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-no-scaling/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-no-scaling/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-no-scaling/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-no-trim/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-no-trim/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-no-trim/lr-with-trim-tolerance/output/lr_with_trim_tolerance_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-no-trim/lr-with-trim-tolerance/output/lr_with_trim_tolerance_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-no-trim/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-no-trim/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-object/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-object/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-object/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-object/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-custom-sections/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-with-custom-sections/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-custom-sections/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-with-custom-sections/output/model_comparison_rsmsummarize.json
@@ -22,5 +22,8 @@
     "file_format": "csv",
     "special_sections": null,
     "subgroups": [],
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-h2/lr-with-h2/output/lr_with_h2_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-with-h2/lr-with-h2/output/lr_with_h2_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-h2/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-with-h2/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-tsv-inputs/lr-with-tsv-output/output/lr_with_tsv_output_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-with-tsv-inputs/lr-with-tsv-output/output/lr_with_tsv_output_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-tsv-inputs/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-with-tsv-inputs/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-tsv-output/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-with-tsv-output/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-tsv-output/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-with-tsv-output/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-xlsx-output/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary-with-xlsx-output/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary-with-xlsx-output/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary-with-xlsx-output/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/lr-self-summary/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-self-summary/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/lr-self-summary/output/model_comparison_rsmsummarize.json
@@ -15,5 +15,8 @@
     "custom_sections": null,
     "subgroups": [],
     "section_order": null,
-    "experiment_names": null
+    "experiment_names": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-with-continuous-human-scores-in-test/output/lr_with_continuous_human_scores_in_test_rsmtool.json
+++ b/tests/data/experiments/lr-with-continuous-human-scores-in-test/output/lr_with_continuous_human_scores_in_test_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/lr-with-continuous-human-scores/output/lr_with_continuous_human_scores_rsmtool.json
+++ b/tests/data/experiments/lr-with-continuous-human-scores/output/lr_with_continuous_human_scores_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/summary-with-custom-names/logistic-regression-expected-scores/output/LogisticRegression_expected_scores_rsmtool.json
+++ b/tests/data/experiments/summary-with-custom-names/logistic-regression-expected-scores/output/LogisticRegression_expected_scores_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/summary-with-custom-names/lr-subgroups/output/lr_subgroups_rsmtool.json
+++ b/tests/data/experiments/summary-with-custom-names/lr-subgroups/output/lr_subgroups_rsmtool.json
@@ -43,6 +43,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/summary-with-custom-names/output/model_comparison_rsmsummarize.json
+++ b/tests/data/experiments/summary-with-custom-names/output/model_comparison_rsmsummarize.json
@@ -21,5 +21,8 @@
     "special_sections": null,
     "custom_sections": null,
     "subgroups": [],
-    "section_order": null
+    "section_order": null,
+    "use_wandb": false,
+    "wandb_project": null,
+    "wandb_entity": null
 }

--- a/tests/data/experiments/svc-custom-objective/output/SVC_custom_objective_rsmtool.json
+++ b/tests/data/experiments/svc-custom-objective/output/SVC_custom_objective_rsmtool.json
@@ -40,6 +40,6 @@
     "flag_column_test": null,
     "min_items_per_candidate": null,
     "use_wandb": false,
-    "wandb_project": "",
-    "wandb_entity": ""
+    "wandb_project": null,
+    "wandb_entity": null
 }


### PR DESCRIPTION
This release PR for v11.0.1 makes the following changes:

-  Update version number.
- Update conda recipe to use `wandb` and cleaned up unneeded requirements.
- Update release documentation to use `nose2` for testing.
- Updated the README to include `wandb` in the requirement list.
- Update some test outputs where the new `wandb` config fields were missing.
    
Note: we had to use `v11.0.1` because the TestPyPI package for v11.0.0 failed (due to conflicts in the requirements which are fixed in this PR) and TestPyPI doesn't let you reuse version numbers once they have been uploaded. 

The conda and TestPyPI packages were built and uploaded. Both pass tests as shown in these PRs:

- [Conda Tester](https://github.com/EducationalTestingService/rsmtool-conda-tester/pull/20)
- [PyPI Tester](https://github.com/EducationalTestingService/rsmtool-pip-tester/pull/17)

As always, please test both the conda and TestPyPI package locally on either Linux or macOS by installing them and trying to run some small tests or one of the examples.

- To install the conda package, run `mamba create -n rsmtest -c ets -c conda-forge python=3.11 rsmtool`. You can choose to use Python 3.8, 3.9, 3.10, 3.11. 
- To install the TestPyPI package, create a conda environment with either Python 3.8, 3.9, 3.10, or 3.11 first and then run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rsmtool`.