### PR TITLE
Update pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-ast
       - id: debug-statements
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: 'v2.3.0'
+    rev: 'v2.4.0'
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
@@ -25,7 +25,7 @@ repos:
       - id: black
         args: [--line-length=100]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.281'
+    rev: 'v0.0.285'
     hooks:
       - id: ruff
         args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D100,tests/test*.py:D101,tests/test*.py:D102,tests/test*.py:D103"]

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -41,7 +41,9 @@ The RSMTool codebase enforces a certain code style via pre-commit checks and thi
 
 #. The f-string specification is used for all format strings in the Python code as enforced by the `flynt <https://pypi.org/project/flynt/>`_ pre-commit check.
 
-#. Any `PEP 8 <https://peps.python.org/pep-0008/>`_ code style violations are checked using the `flake8 <https://flake8.pycqa.org/en/latest/>`_ pre-commit check.
+#. Any code violations for `PEP 8 <https://peps.python.org/pep-0008/>`_, `PEP 257 <https://peps.python.org/pep-0257/>`_, and import statements are checked using the `ruff <https://github.com/astral-sh/ruff-pre-commit>`_ pre-commit check.
+
+#. Commit messages must follow the `conventional commit specification <https://www.conventionalcommits.org/en/v1.0.0/#summary>`_. This is enforced by the `conventional-pre-commit <https://github.com/compilerla/conventional-pre-commit>`_ pre-commit check.
 
 #. The imports at the top of any Python files are grouped and sorted as follows: STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER. As an example, consider the imports at the top of ``reporter.py`` which look like this:
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -20,7 +20,7 @@ To set up a local development environment, follow the steps below:
 
 #. Run ``pip install -e .`` to install rsmtool into the environment in editable mode which is what we need for development.
 
-#. Run ``pre-commit install`` to install the git hooks for pre-commit checks.
+#. Run ``pre-commit install --hook-type pre-commit --hook-type commit-msg --overwrite --install-hooks`` to install the git hooks for pre-commit checks.
 
 #. Create a new git branch with a useful and descriptive name.
 


### PR DESCRIPTION
This PR:
- updates the pre-commit checks to their latest versions
- updates `contributing.md` to use correct pre-commit install command

To test this, check out this branch and run the command in `contributing.md`. Then try to make a commit with a random commit message, it should fail. 
