### PR TITLE
Enhance wandb logging of evaluation metrics

### DIFF
--- a/examples/rsmtool/config_rsmtool.json
+++ b/examples/rsmtool/config_rsmtool.json
@@ -11,5 +11,5 @@
     "trim_max": 6,
     "id_column": "ID",
     "second_human_score_column": "score2",
-    "length_column": "LENGTH"
+    "length_column": "LENGTH
 }

--- a/examples/rsmtool/config_rsmtool.json
+++ b/examples/rsmtool/config_rsmtool.json
@@ -11,5 +11,8 @@
     "trim_max": 6,
     "id_column": "ID",
     "second_human_score_column": "score2",
-    "length_column": "LENGTH"
+    "length_column": "LENGTH",
+    "use_wandb": true,
+    "wandb_project": "rsmtool_tutorial",
+    "wandb_entity": "etslabs"
 }

--- a/examples/rsmtool/config_rsmtool.json
+++ b/examples/rsmtool/config_rsmtool.json
@@ -11,8 +11,5 @@
     "trim_max": 6,
     "id_column": "ID",
     "second_human_score_column": "score2",
-    "length_column": "LENGTH",
-    "use_wandb": true,
-    "wandb_project": "rsmtool_tutorial",
-    "wandb_entity": "etslabs"
+    "length_column": "LENGTH"
 }

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -1689,7 +1689,7 @@ class Analyzer:
             "use_scaled_predictions"}.
 
         wandb_run : wandb.Run
-            The wandb run object if wandb is enabled, None otherwise.
+            The wandb run object if wandb is enabled, ``None`` otherwise.
             If enabled, all the output data frames will be logged to
             this run as tables.
             Defaults to ``None``.

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -20,6 +20,7 @@ from sklearn.metrics import confusion_matrix, mean_squared_error, r2_score
 from skll.metrics import kappa
 
 from .container import DataContainer
+from .utils import wandb
 from .utils.metrics import (
     agreement,
     difference_of_standardized_means,
@@ -1670,7 +1671,7 @@ class Analyzer:
 
         return configuration, DataContainer(datasets=datasets)
 
-    def run_prediction_analyses(self, data_container, configuration):
+    def run_prediction_analyses(self, data_container, configuration, wandb_run=None):
         """
         Run all analyses on the system scores (predictions).
 
@@ -1686,6 +1687,12 @@ class Analyzer:
             The Configuration object.  This configuration object must include the
             following parameters (keys):  {"subgroups", "second_human_score_column",
             "use_scaled_predictions"}.
+
+        wandb_run : wandb.Run
+            The wandb run object if wandb is enabled, None otherwise.
+            If enabled, all the output data frames will be logged to
+            this run as tables.
+            Defaults to ``None``.
 
         Returns
         -------
@@ -1790,6 +1797,8 @@ class Analyzer:
         conf_matrix = confusion_matrix(human_scores, system_scores)
         labels = sorted(pd.concat([human_scores, system_scores]).unique())
         df_confmatrix = pd.DataFrame(conf_matrix, index=labels, columns=labels).transpose()
+        # log confusion matrix to W&B
+        wandb.log_confusion_matrix(wandb_run, human_scores, system_scores, labels)
 
         # compute the score distributions of the rounded human and system scores
         df_score_dist = df_preds[["sc1_round", f"{score_type}_trim_round"]].apply(

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -1798,7 +1798,9 @@ class Analyzer:
         labels = sorted(pd.concat([human_scores, system_scores]).unique())
         df_confmatrix = pd.DataFrame(conf_matrix, index=labels, columns=labels).transpose()
         # log confusion matrix to W&B
-        wandb.log_confusion_matrix(wandb_run, human_scores, system_scores, labels)
+        wandb.log_confusion_matrix(
+            wandb_run, human_scores, system_scores, labels, "Human-System Confusion Matrix"
+        )
 
         # compute the score distributions of the rounded human and system scores
         df_score_dist = df_preds[["sc1_round", f"{score_type}_trim_round"]].apply(
@@ -1817,6 +1819,9 @@ class Analyzer:
             df_confmatrix_h1h2 = pd.DataFrame(
                 conf_matrix_h1h2, index=labels, columns=labels
             ).transpose()
+            wandb.log_confusion_matrix(
+                wandb_run, human1_scores, human2_scores, labels, "Human1-Human2 Confusion Matrix"
+            )
 
         # Replace any NaNs, which we might get because our model never
         # predicts a particular score label, with zeros.

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -1799,7 +1799,7 @@ class Analyzer:
         df_confmatrix = pd.DataFrame(conf_matrix, index=labels, columns=labels).transpose()
         # log confusion matrix to W&B
         wandb.log_confusion_matrix(
-            wandb_run, human_scores, system_scores, labels, "Human-System Confusion Matrix"
+            wandb_run, human_scores, system_scores, "Human-System Confusion Matrix"
         )
 
         # compute the score distributions of the rounded human and system scores
@@ -1820,7 +1820,7 @@ class Analyzer:
                 conf_matrix_h1h2, index=labels, columns=labels
             ).transpose()
             wandb.log_confusion_matrix(
-                wandb_run, human1_scores, human2_scores, labels, "Human1-Human2 Confusion Matrix"
+                wandb_run, human1_scores, human2_scores, "Human1-Human2 Confusion Matrix"
             )
 
         # Replace any NaNs, which we might get because our model never

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -203,7 +203,9 @@ def run_evaluation(
     (
         pred_analysis_config,
         pred_analysis_data_container,
-    ) = analyzer.run_prediction_analyses(for_pred_data_container, analyzed_config)
+    ) = analyzer.run_prediction_analyses(
+        for_pred_data_container, analyzed_config, wandb_run=wandb_run
+    )
 
     writer.write_experiment_output(
         csvdir, pred_analysis_data_container, reset_index=True, file_format=file_format

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -333,7 +333,7 @@ def run_experiment(
     (
         pred_analysis_config,
         pred_analysis_data_container,
-    ) = analyzer.run_prediction_analyses(new_pred_data_container, pred_config)
+    ) = analyzer.run_prediction_analyses(new_pred_data_container, pred_config, wandb_run)
 
     # Write out files
     writer.write_experiment_output(

--- a/rsmtool/utils/wandb.py
+++ b/rsmtool/utils/wandb.py
@@ -11,7 +11,7 @@ EXCLUDE = ["confMatrix", "confMatrix_h1h2"]
 
 # all values from these dataframes will be logged to the
 # run as metrics in addition to logging as a table artifact.
-LOG_METRICS = ["eval_short", "eval_short", "consistency"]
+LOG_METRICS = ["consistency", "eval_short", "true_score_eval"]
 
 
 def init_wandb_run(config_obj):

--- a/rsmtool/utils/wandb.py
+++ b/rsmtool/utils/wandb.py
@@ -86,7 +86,7 @@ def log_dataframe_to_wandb(wandb_run, df, df_name):
             wandb_run.log(metric_dict)
 
 
-def log_confusion_matrix(wandb_run, human_scores, system_scores, labels, name):
+def log_confusion_matrix(wandb_run, human_scores, system_scores, name):
     """
     Log a confusion matrix to W&B if logging to W&B is enabled.
 

--- a/rsmtool/utils/wandb.py
+++ b/rsmtool/utils/wandb.py
@@ -7,7 +7,7 @@ import wandb
 
 # excluded dataframes will not be logged as tables or metrics.
 # confusion matrices are logged separately.
-EXCLUDE = ["confMatrix"]
+EXCLUDE = ["confMatrix", "confMatrix_h1h2"]
 
 # all values from these dataframes will be logged to the
 # run as metrics in addition to logging as a table artifact.
@@ -83,10 +83,10 @@ def log_dataframe_to_wandb(wandb_run, df, df_name):
                 metric_dict.update(
                     {f"{df_name}.{column}": value for _, value in col_dict.items() if value}
                 )
-                wandb_run.log(metric_dict)
+            wandb_run.log(metric_dict)
 
 
-def log_confusion_matrix(wandb_run, human_scores, system_scores, labels):
+def log_confusion_matrix(wandb_run, human_scores, system_scores, labels, name):
     """
     Log a confusion matrix to W&B if logging to W&B is enabled.
 
@@ -101,17 +101,19 @@ def log_confusion_matrix(wandb_run, human_scores, system_scores, labels):
     system_scores : Sequence
         The predicted scores for the responses in the data
     labels : Sequence
-        All the
+        A list of all the labels in the data
+    name : str
+        The chart title
     """
     if wandb_run:
         wandb_run.log(
             {
-                "conf_mat": wandb.plot.confusion_matrix(
+                name: wandb.plot.confusion_matrix(
                     probs=None,
                     y_true=human_scores,
                     preds=system_scores,
                     class_names=labels,
-                    title="Confusion Matrix",
+                    title=name,
                 )
             }
         )

--- a/rsmtool/utils/wandb.py
+++ b/rsmtool/utils/wandb.py
@@ -100,8 +100,6 @@ def log_confusion_matrix(wandb_run, human_scores, system_scores, labels, name):
         The human scores for the responses in the data
     system_scores : Sequence
         The predicted scores for the responses in the data
-    labels : Sequence
-        A list of all the labels in the data
     name : str
         The chart title
     """
@@ -112,7 +110,6 @@ def log_confusion_matrix(wandb_run, human_scores, system_scores, labels, name):
                     probs=None,
                     y_true=human_scores,
                     preds=system_scores,
-                    class_names=labels,
                     title=name,
                 )
             }

--- a/rsmtool/utils/wandb.py
+++ b/rsmtool/utils/wandb.py
@@ -104,8 +104,8 @@ def get_metric_name(df_name, col_name, row_name):
         The dataframe name
     col_name : str
         The column name
-    row_name : str
-        The row name
+    row_name : Union[int,str]
+        The row name, or 0 for some single line dataframes.
 
     Returns
     -------

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -164,13 +164,15 @@ class TestExperimentRsmtool4(unittest.TestCase):
         with self.assertRaises(ValueError):
             run_experiment(config, output_dir, overwrite_output=True)
 
-    def test_run_experiment_with_wandb(self):
+    @patch("wandb.init")
+    @patch("wandb.plot.confusion_matrix")
+    def test_run_experiment_with_wandb(self, mock_wandb_init, mock_plot_conf_mat):
         source = "wandb"
         experiment_id = "wandb"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         mock_wandb_run = Mock()
-        with patch("wandb.init") as mock_wandb_init:
-            mock_wandb_init.return_value = mock_wandb_run
-            do_run_experiment(source, experiment_id, config_file)
+        mock_wandb_init.return_value = mock_wandb_run
+        do_run_experiment(source, experiment_id, config_file)
         mock_wandb_init.assert_called_with(project="wandb_project", entity="wandb_entity")
         mock_wandb_run.log_artifact.assert_called_once()
+        mock_plot_conf_mat.assert_called()

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -166,7 +166,7 @@ class TestExperimentRsmtool4(unittest.TestCase):
 
     @patch("wandb.init")
     @patch("wandb.plot.confusion_matrix")
-    def test_run_experiment_with_wandb(self, mock_wandb_init, mock_plot_conf_mat):
+    def test_run_experiment_with_wandb(self, mock_plot_conf_mat, mock_wandb_init):
         source = "wandb"
         experiment_id = "wandb"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from rsmtool.configuration_parser import Configuration
 from rsmtool.utils.wandb import (
+    get_metric_name,
     init_wandb_run,
     log_configuration_to_wandb,
     log_dataframe_to_wandb,
@@ -118,3 +119,12 @@ class TestWandb(unittest.TestCase):
             # assert that no calls to wandb objects have been made
             mock_wandb_artifact.assert_not_called()
             mock_report_artifact.add_file.assert_not_called()
+
+    def test_get_metric_name(self):
+        """Test the method get_metric_name."""
+        # with a valid row name
+        self.assertEquals("df.col.row", get_metric_name("df", "col", "row"))
+        # with an empty row name
+        self.assertEquals("df.col", get_metric_name("df", "col", ""))
+        # with 0 as row name
+        self.assertEquals("df.col", get_metric_name("df", "col", 0))


### PR DESCRIPTION
- log all the values of the following tables as run metrics: `consistency`, `eval_short`, `true_score_eval`. This allows easy comparison between runs in the [runs view](https://wandb.ai/etslabs/rsmtool_tutorial/table?workspace=user-tamarlv)

- log confusion matrices as custom charts, this also allows comparing between runs - see in the [workspace view](https://wandb.ai/etslabs/rsmtool_tutorial/workspace?workspace=user-tamarlv)

@desilinguist @mulhod The changes make the tutorial run quite slow for me. Please test and let me know what you think.
to test add the following to `rsmtool` / `rsmeval` tutorial config (change project name accordingly), and run it in this branch:
``` 
    "use_wandb": true,
    "wandb_project": "rsmtool_tutorial",
    "wandb_entity": "etslabs"
```