### PR TITLE
Bug fixes in xval and report

### DIFF
--- a/rsmtool/notebooks/consistency.ipynb
+++ b/rsmtool/notebooks/consistency.ipynb
@@ -89,7 +89,7 @@
     "                            formatters=formatter_dict, escape=False)))\n",
     "\n",
     "    if exists(confmat_h1h2_file):\n",
-    "        markdown_strs = ['### Confusion matrix']\n",
+    "        markdown_strs = ['### Human-human confusion matrix']\n",
     "        markdown_strs.append(\"Confusion matrix using the two human scores (rows=human #1, columns=human #2).\"\n",
     "                             \" Note that the matrix is computed on the subset of responses that were \"\n",
     "                             \"double-scored.\")\n",

--- a/rsmtool/notebooks/evaluation.ipynb
+++ b/rsmtool/notebooks/evaluation.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "markdown_str = [\"Confusion matrix using {}, trimmed, and rounded scores and human scores (rows=system, columns=human).\".format(raw_or_scaled)]\n",
+    "markdown_str = [\"Confusion matrix using {}, trimmed, and rounded scores and human scores (rows=human, columns=system).\".format(raw_or_scaled)]\n",
     "\n",
     "if continuous_human_score:\n",
     "    markdown_str.append(\"Note: Human scores have beeen rounded to the nearest integer.\")\n",

--- a/rsmtool/utils/cross_validation.py
+++ b/rsmtool/utils/cross_validation.py
@@ -128,7 +128,6 @@ def create_xval_files(configuration, output_dir, logger=None):
     # iterate over each of the folds and generate an rsmtool configuration file
     # which is then saved to disk in a directory specific to each fold
     for fold_num, (fold_train_indices, fold_test_indices) in enumerate(fold_generator, start=1):
-
         # get the train and test files for this fold and
         # write them out to disk
         df_fold_train = df_train.loc[fold_train_indices]
@@ -239,6 +238,6 @@ def combine_fold_prediction_files(foldsdir, file_format="csv"):
 
     # concatenate all of the predictions into a single frame using
     # "spkitemid" column which must exist since this is the output of RSMTool
-    df_all_predictions = concat(prediction_dfs, keys="spkitemid").reset_index(drop=True)
+    df_all_predictions = concat(prediction_dfs).reset_index(drop=True)
 
     return df_all_predictions


### PR DESCRIPTION
- fix the concatenation of prediction files from xval folds, which used the `keys` param incorrectly and unnecessarily. This caused a bug only with more than 9 folds.
- added a 10-fold scenario to the test of that method
- fixed the description of human-system confusion matrix to match the matrix axes values.
- changed the title of human-human confusion matrix to be different than the human-system one, so that the links at the top works correctly.