### PR TITLE
Fix new warnings & remove manual suppressions

### DIFF
--- a/rsmtool/notebooks/comparison/header.ipynb
+++ b/rsmtool/notebooks/comparison/header.ipynb
@@ -30,17 +30,6 @@
     "                        category=TqdmExperimentalWarning, \n",
     "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
     "                        module=\"shap.explainers._linear\")\n",
-    "\n",
-    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=UserWarning, \n",
-    "                        message=\".*figure layout.*\", \n",
-    "                        module=\"seaborn.axisgrid\")\n",
-    "# warning from seaborn about a deprecated method in pandas\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=FutureWarning, \n",
-    "                        message=\".*is_categorical_dtype is deprecated.*\", \n",
-    "                        module=\"seaborn\")\n",
     "\n"
    ]
   },

--- a/rsmtool/notebooks/dff_by_group.ipynb
+++ b/rsmtool/notebooks/dff_by_group.ipynb
@@ -68,7 +68,7 @@
     "        with sns.axes_style('whitegrid'), sns.plotting_context('notebook', font_scale=1.2):\n",
     "            p = sns.catplot(x='sc1', y='value', hue=group, hue_order = group_values,\n",
     "                            col='feature', col_wrap=col_wrap, height=height, aspect=aspect,\n",
-    "                            scale=0.6,\n",
+    "                            markersize=4,\n",
     "                            palette=colors,\n",
     "                            sharey=False, sharex=False, legend=False, kind=\"point\",\n",
     "                            data=df_melted)\n",

--- a/rsmtool/notebooks/evaluation_by_group.ipynb
+++ b/rsmtool/notebooks/evaluation_by_group.ipynb
@@ -77,7 +77,7 @@
     "                for lineval in metrics[metric]:\n",
     "                    ax.axhline(y=float(lineval), linestyle='--', linewidth=0.5, color='black')\n",
     "                sns.barplot(x=df_plot[group], y=df_plot[metric], color='grey', ax=ax, order=bar_names)\n",
-    "                ax.set_xticklabels(wrapped_bar_names, rotation=90) \n",
+    "                ax.set_xticks(ax.get_xticks(), wrapped_bar_names, rotation=90) \n",
     "                ax.set_xlabel('')\n",
     "                ax.set_ylabel('')\n",
     "\n",

--- a/rsmtool/notebooks/explanations/header.ipynb
+++ b/rsmtool/notebooks/explanations/header.ipynb
@@ -30,17 +30,6 @@
     "                        category=TqdmExperimentalWarning, \n",
     "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
     "                        module=\"shap.explainers._linear\")\n",
-    "\n",
-    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=UserWarning, \n",
-    "                        message=\".*figure layout.*\", \n",
-    "                        module=\"seaborn.axisgrid\")",
-    "# warning from seaborn about a deprecated method in pandas\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=FutureWarning, \n",
-    "                        message=\".*is_categorical_dtype is deprecated.*\", \n",
-    "                        module=\"seaborn\")\n",
     "\n"
    ]
   },

--- a/rsmtool/notebooks/features_by_group.ipynb
+++ b/rsmtool/notebooks/features_by_group.ipynb
@@ -83,7 +83,7 @@
     "                    ax.axhline(y=float(min_value), linestyle='--', linewidth=0.5, color='r')\n",
     "                    ax.axhline(y=float(max_value), linestyle='--', linewidth=0.5, color='r')\n",
     "                    sns.boxplot(x=df_plot[group], y=df_plot[varname], color='#b3b3b3', ax=ax, order=box_names)\n",
-    "                    ax.set_xticklabels(wrapped_box_names, rotation=90) \n",
+    "                    ax.set_xticks(ax.get_xticks(), wrapped_box_names, rotation=90) \n",
     "                    ax.set_xlabel('')\n",
     "                    ax.set_ylabel('')\n",
     "                    plot_title = '{} by {}'.format('\\n'.join(wrap(varname, 30)), group)\n",

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -28,18 +28,6 @@
     "                        category=TqdmExperimentalWarning, \n",
     "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
     "                        module=\"shap.explainers._linear\")\n",
-    "\n",
-    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=UserWarning, \n",
-    "                        message=\".*figure layout.*\", \n",
-    "                        module=\"seaborn.axisgrid\")\n",
-    "\n",
-    "# warning from seaborn about a deprecated method in pandas\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=FutureWarning, \n",
-    "                        message=\".*is_categorical_dtype is deprecated.*\", \n",
-    "                        module=\"seaborn\")\n",
     "\n"
    ]
   },

--- a/rsmtool/notebooks/pca.ipynb
+++ b/rsmtool/notebooks/pca.ipynb
@@ -54,7 +54,7 @@
     "                                    linewidth=1, use_index=True, xticks=range(num_components),\n",
     "                                    figsize=(11, 5), title='Scree Plot: Principal Component Analysis')\n",
     "    ax.set_ylabel('Variances')\n",
-    "    ax.set_xticklabels(labels, rotation=90)\n",
+    "    ax.set_xticks(ax.get_xticks(), labels, rotation=90)\n",
     "    imgfile = join(figure_dir, '{}_pca.svg'.format(experiment_id))\n",
     "    plt.savefig(imgfile)\n",
     "    if use_thumbnails:\n",

--- a/rsmtool/notebooks/preprocessed_features.ipynb
+++ b/rsmtool/notebooks/preprocessed_features.ipynb
@@ -62,7 +62,7 @@
     "        for ax, cname in zip(g.axes, g.col_names):\n",
     "            labels = ax.get_xticks()\n",
     "            ax.set_xlabel('')\n",
-    "            ax.set_xticklabels(labels, rotation=90)\n",
+    "            ax.set_xticks(ax.get_xticks(), labels, rotation=90)\n",
     "            plot_title = '\\n'.join(wrap(str(cname), 30))\n",
     "            ax.set_title(plot_title)\n",
     "\n",

--- a/rsmtool/notebooks/summary/header.ipynb
+++ b/rsmtool/notebooks/summary/header.ipynb
@@ -30,17 +30,6 @@
     "                        category=TqdmExperimentalWarning, \n",
     "                        message=\"Using `tqdm.autonotebook.tqdm` .*\", \n",
     "                        module=\"shap.explainers._linear\")\n",
-    "\n",
-    "# warning from matplotlib -> seaborn when figure layouts are changed to \"tight\"\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=UserWarning, \n",
-    "                        message=\".*figure layout.*\", \n",
-    "                        module=\"seaborn.axisgrid\")",
-    "# warning from seaborn about a deprecated method in pandas\n",
-    "warnings.filterwarnings(\"ignore\", \n",
-    "                        category=FutureWarning, \n",
-    "                        message=\".*is_categorical_dtype is deprecated.*\", \n",
-    "                        module=\"seaborn\")\n",
     "\n"
    ]
   },


### PR DESCRIPTION
- Replace `set_xticklabels()` calls in several notebooks since the new version of matplotlib discourages the use of `set_xticklabels()` and displays warnings in the notebook. The recommended replacement is to use `set_xticks()` instead.
- Replace `scale` in `sns.catplot()` since `seaborn` is deprecating the `scale` parameter and encourages the use of `matplotlib` Line2D parameters directly, i.e., `markersize`. However, the units are different.
- Remove unneeded warning suppressions. The latest version of `seaborn` and `matplotlib` no longer generate the two types of warnings we were manually suppressing.

I ran `STRICT=1 nose2 -s tests` and all tests passed which means there were no warnings generated in notebooks. To double check, I ran `grep ' output_error ' test_outputs/*/report/*.html` and this confirmed that there were no unexpected warnings generated. 

To review:

1. Run a few experiments manually to see that no warnings are generated.
2. Run `STRICT=1 nose2 -s tests` using a python 3.8 environment (mine was 3.11) and check that there were no warnings generated using the methods I suggested above.
3. Review the actual changes made to the code.

Closes #655. 
