### PR TITLE
Refactor CLI tests to modernize codecov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
 # set up basic job
 .runtests:
   before_script:
-    - "mamba create --prefix /root/rsmenv -c conda-forge -c ets --file requirements.txt python=${PYVERSION} --yes"
+    - "mamba create --prefix /root/rsmenv -c conda-forge -c ets --file requirements.txt python=${PYVERSION} curl --yes"
     - /root/rsmenv/bin/pip install -e .
     - /root/rsmenv/bin/curl -o /root/rsmenv/bin/codecov https://uploader.codecov.io/latest/linux/codecov
     - chmod +x /root/rsmenv/bin/codecov

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
 variables:
   PYVERSION: "3.8"
   BINPATH: "/root/rsmenv/bin"
+  LOGCAPTURE_LEVEL: "WARNING"
   CODECOV_TOKEN: "488304b7-b1c5-4fc7-bfb6-9e7cbcb36a08"
 
 # set up basic job
@@ -13,6 +14,8 @@ variables:
   before_script:
     - "mamba create --prefix /root/rsmenv -c conda-forge -c ets --file requirements.txt python=${PYVERSION} --yes"
     - /root/rsmenv/bin/pip install -e .
+    - /root/rsmenv/bin/curl -o /root/rsmenv/bin/codecov https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x /root/rsmenv/bin/codecov
     - echo "import os" > sitecustomize.py
     - echo "try:" >> sitecustomize.py
     - echo "    import coverage" >> sitecustomize.py
@@ -22,6 +25,7 @@ variables:
     - echo "    pass" >> sitecustomize.py
   script:
     - "/root/rsmenv/bin/nose2 -s tests ${TESTFILES}"
+    - "/root/rsmenv/bin/coverage xml"
   after_script:
     - /root/rsmenv/bin/codecov
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-codecov
 doc2dash
 ipython
 jupyter

--- a/rsmtool/rsmcompare.py
+++ b/rsmtool/rsmcompare.py
@@ -178,7 +178,11 @@ def run_comparison(config_file_or_obj_or_dict, output_dir):
     )
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -200,22 +204,22 @@ def main():  # noqa: D103
     parser = setup_rsmcmd_parser("rsmcompare", uses_output_directory=True, uses_subgroups=True)
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -219,7 +219,11 @@ def run_evaluation(
     reporter.create_report(pred_analysis_config, csvdir, figdir, context="rsmeval")
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -246,22 +250,22 @@ def main():  # noqa: D103
     )
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/rsmtool/rsmexplain.py
+++ b/rsmtool/rsmexplain.py
@@ -525,8 +525,12 @@ def generate_report(explanation, output_dir, ids, configuration, logger=None, wa
     reporter.create_explanation_report(configuration, csvdir, reportdir)
 
 
-def main():
+def main(argv=None):
     """Run rsmexplain and generate explanation reports."""
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -546,22 +550,22 @@ def main():
     parser = setup_rsmcmd_parser("rsmexplain", uses_output_directory=True, allows_overwriting=True)
 
     # if no arguments provided then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     if args.subcommand == "run":

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -505,7 +505,11 @@ def compute_and_save_predictions(
         )
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -540,22 +544,22 @@ def main():  # noqa: D103
     )
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -235,7 +235,11 @@ def run_summary(
     reporter.create_summary_report(configuration, all_experiments, csvdir)
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -259,22 +263,22 @@ def main():  # noqa: D103
     )
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -347,7 +347,11 @@ def run_experiment(
     reporter.create_report(pred_analysis_config, csvdir, figdir)
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -374,22 +378,22 @@ def main():  # noqa: D103
     )
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/rsmtool/rsmxval.py
+++ b/rsmtool/rsmxval.py
@@ -268,7 +268,11 @@ def run_cross_validation(
     )
 
 
-def main():  # noqa: D103
+def main(argv=None):  # noqa: D103
+    # if no arguments are passed, then use sys.argv
+    if argv is None:
+        argv = sys.argv[1:]
+
     # set up the basic logging configuration
     formatter = LogFormatter()
 
@@ -295,22 +299,22 @@ def main():  # noqa: D103
     )
 
     # if we have no arguments at all then just show the help message
-    if len(sys.argv) < 2:
-        sys.argv.append("-h")
+    if len(argv) < 1:
+        argv.append("-h")
 
     # if the first argument is not one of the valid sub-commands
     # or one of the valid optional arguments, then assume that they
     # are arguments for the "run" sub-command. This allows the
     # old style command-line invocations to work without modification.
-    if sys.argv[1] not in VALID_PARSER_SUBCOMMANDS + [
+    if argv[0] not in VALID_PARSER_SUBCOMMANDS + [
         "-h",
         "--help",
         "-V",
         "--version",
     ]:
-        args_to_pass = ["run"] + sys.argv[1:]
+        args_to_pass = ["run"] + argv
     else:
-        args_to_pass = sys.argv[1:]
+        args_to_pass = argv
     args = parser.parse_args(args=args_to_pass)
 
     # call the appropriate function based on which sub-command was run

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
+from shutil import rmtree
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest.mock import patch
 
@@ -75,7 +76,7 @@ class TestToolCLI(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for tempdir in cls.temporary_directories:
-            tempdir.cleanup()
+            rmtree(tempdir.name, ignore_errors=True)
         for tempfile in cls.temporary_files:
             os.unlink(tempfile)
 


### PR DESCRIPTION
- All tools main functions now take arguments. This is needed to refactor the CLI tests so that they call the main functions directly instead of using subprocess calls.
- Refactor the CLI tests since we want to be able to use the command-line `codecov` tool which does not measure subprocess coverage.
- Switch to `codecov` binary in the Gitlab CI plan and install `curl` so we can download that binary in the first place.
- Ignore cleanup errors in `test_cli.py`.

Notes:
1. A side-benefit of this change is that `test_cli.py` now runs 3x faster since we aren't using subprocesses.
2. The coverage change is expected since we are changing the total number of lines in the code.

Closes #638. 
