### PR TITLE
Pin numpy to < 2

### DIFF
--- a/conda-recipe/rsmtool/meta.yaml
+++ b/conda-recipe/rsmtool/meta.yaml
@@ -31,13 +31,13 @@ requirements:
     - ipython
     - jupyter
     - notebook
-    - numpy<1.25
+    - numpy<2
     - openpyxl
     - pandas
     - python
     - seaborn
     - shap
-    - skll==4.0.0
+    - skll==4.0.1
     - statsmodels
     - tqdm
     - wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ipython
 jupyter
 nose2
 notebook
-numpy
+numpy<2
 openpyxl
 pandas
 pre-commit


### PR DESCRIPTION
This is to avoid any potential failures when numpy 2 comes out since it breaks backward compatibility.

Closes #671. 
