### PR TITLE
Add type hints (Part 2)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,12 +37,26 @@ from rsmtool.version import __version__ as version  # isort:skip # noqa
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx.ext.intersphinx",
     "sphinx_design",
 ]
+
+# link to other projects' documentation
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "skll": ("https://skll.readthedocs.io/en/latest", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+}
+
+# some settings for sphinx_autodoc_typehints
+typehints_use_signature = True
+typehints_use_signature_return = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,5 +5,6 @@ skll==4.0.1
 sphinx
 sphinx_rtd_theme
 sphinx-design
+sphinx-autodoc-typehints
 statsmodels
 wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ skll==4.0.1
 sphinx
 sphinx-design
 sphinx_rtd_theme
+sphinx-autodoc-typehints
 statsmodels
 tqdm
 wandb

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -1067,7 +1067,7 @@ class Analyzer:
         df: pd.DataFrame,
         compute_shortened: bool = False,
         use_scaled_predictions: bool = False,
-        include_second_score=False,
+        include_second_score: bool = False,
         population_sd_dict: Optional[Dict[str, Optional[float]]] = None,
         population_mn_dict: Optional[Dict[str, Optional[float]]] = None,
         smd_method: str = "unpooled",

--- a/rsmtool/comparer.py
+++ b/rsmtool/comparer.py
@@ -116,11 +116,11 @@ class Comparer:
 
         Returns
         -------
-        rename_dict_new : dict
+        rename_dict_new : Dict[str, str]
             The updated rename dictionary.
-        existing_eval_cols_new : list
+        existing_eval_cols_new : List[str]
             The updated existing evaluation columns
-        short_metrics_list_new : list
+        short_metrics_list_new : List[str]
             The updated list of columns for the short metrics file.
         smd_name : str
             The SMD column name (either 'SMD' or 'DSM')
@@ -336,10 +336,10 @@ class Comparer:
             Path to the directory containing output figures.
         experiment_id : str
             Original ``experiment_id`` used to generate the output files.
-        prefix: str
+        prefix : str
             Must be set to ``"scale"`` or ``"raw"``. Indicates whether the score
             is scaled or not.
-        groups_eval: list
+        groups_eval: List[str]
             List of subgroup names used for subgroup evaluation.
 
         Returns

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -11,6 +11,8 @@ and creating configuration objects.
 :organization: ETS
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re
@@ -38,8 +40,8 @@ from .utils.models import is_skll_model
 
 
 def configure(
-    context: str, config_file_or_obj_or_dict: Union[str, "Configuration", Dict[str, Any], Path]
-) -> "Configuration":
+    context: str, config_file_or_obj_or_dict: Union[str, Configuration, Dict[str, Any], Path]
+) -> Configuration:
     """
     Create a Configuration object.
 
@@ -357,7 +359,7 @@ class Configuration:
 
         Returns
         -------
-        values : list
+        values : List[Any]
             A list of values in the configuration object.
         """
         return [v for v in self._config.values()]
@@ -373,7 +375,7 @@ class Configuration:
         """
         return [(k, v) for k, v in self._config.items()]
 
-    def pop(self, key, default=None) -> Any:
+    def pop(self, key: str, default: Any = None) -> Any:
         """
         Remove and return an element from the object having the given key.
 
@@ -392,7 +394,7 @@ class Configuration:
         """
         return self._config.pop(key, default)
 
-    def copy(self, deep: bool = True) -> "Configuration":
+    def copy(self, deep: bool = True) -> Configuration:
         """
         Return a copy of the object.
 
@@ -474,11 +476,11 @@ class Configuration:
         partition: str
             The data partition which is filtered based on the flag column name.
             One of {"train", "test", "both", "unknown"}.
-            Defaults to "both".
+            Defaults to "unknown".
 
         Returns
         -------
-        new_filtering_dict : dict
+        new_filtering_dict : Dict[str, List[str]]
             Properly formatted dictionary for the column name in ``flag_column``.
 
         Raises

--- a/rsmtool/configuration_parser.py
+++ b/rsmtool/configuration_parser.py
@@ -137,7 +137,7 @@ class Configuration:
             "rsmpredict", "rsmsummarize"}.
             Defaults to "rsmtool".
         logger : logging object, optional
-            A logging object. If ``None`` is passed, get logger from ``__name__``.
+            A Logger object. If ``None`` is passed, get logger from ``__name__``.
             Defaults to ``None``.
         """
         if not isinstance(configdict, dict):

--- a/rsmtool/container.py
+++ b/rsmtool/container.py
@@ -14,6 +14,8 @@ dataset is represented by three properties:
 :organization: ETS
 """
 
+from __future__ import annotations
+
 import warnings
 from copy import copy, deepcopy
 from typing import Dict, Generator, List, Optional, Tuple, TypedDict
@@ -113,7 +115,7 @@ class DataContainer:
         """
         return ", ".join(self._names)
 
-    def __add__(self, other: "DataContainer") -> "DataContainer":
+    def __add__(self, other: DataContainer) -> DataContainer:
         """
         Add another container object to instance.
 
@@ -164,7 +166,7 @@ class DataContainer:
             yield key
 
     @staticmethod
-    def to_datasets(data_container: "DataContainer") -> List[DatasetDict]:
+    def to_datasets(data_container: DataContainer) -> List[DatasetDict]:
         """
         Convert container object to a list of dataset dictionaries.
 
@@ -178,7 +180,7 @@ class DataContainer:
 
         Returns
         -------
-        datasets_dict : List[DatasetDict]
+        dataset_dicts : List[DatasetDict]
             A list of dataset dictionaries.
         """
         dataset_dicts: List[DatasetDict] = []
@@ -235,7 +237,7 @@ class DataContainer:
 
         Returns
         -------
-        path : str
+        path : Optional[str]
             The path for the named dataset.
         """
         if name not in self._names:
@@ -341,7 +343,7 @@ class DataContainer:
         """
         return [(name, self._dataframes[name]) for name in self._names]
 
-    def drop(self, name: str) -> "DataContainer":
+    def drop(self, name: str) -> DataContainer:
         """
         Drop a given dataset from the container and return instance.
 
@@ -365,7 +367,7 @@ class DataContainer:
             self._data_paths.pop(name)
         return self
 
-    def rename(self, name: str, new_name: str) -> "DataContainer":
+    def rename(self, name: str, new_name: str) -> DataContainer:
         """
         Rename a given dataset in the container and return instance.
 
@@ -390,7 +392,7 @@ class DataContainer:
             self.drop(name)
         return self
 
-    def copy(self, deep: bool = True) -> "DataContainer":
+    def copy(self, deep: bool = True) -> DataContainer:
         """
         Return a copy of the container object.
 

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -46,7 +46,7 @@ def run_evaluation(
 
     Parameters
     ----------
-    config_file_or_obj_or_dict : Union[str, Path, Dict[str, Any]]
+    config_file_or_obj_or_dict : Union[str, Configuration, Dict[str, Any], Path]
         Path to the experiment configuration file either a string
         or as a ``pathlib.Path`` object. Users can also pass a
         ``Configuration`` object that is in memory or a Python dictionary
@@ -62,7 +62,7 @@ def run_evaluation(
         If ``True``, overwrite any existing output under ``output_dir``.
         Defaults to ``False``.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.

--- a/rsmtool/rsmexplain.py
+++ b/rsmtool/rsmexplain.py
@@ -173,7 +173,7 @@ def generate_explanation(
         If ``True``, overwrite any existing output under ``output_dir``.
         Defaults to ``False``.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.
@@ -456,7 +456,7 @@ def generate_report(
     configuration: rsmtool.configuration_parser.Configuration
         The Configuration object for rsmexplain.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -160,7 +160,7 @@ def fast_predict(
        ``scale=True``, a ``ValueError`` will be raised.
        Defaults to ``None``.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
 
     Returns
@@ -331,7 +331,7 @@ def compute_and_save_predictions(
     feats_file : Optional[str]
         Path to the output file for saving preprocessed feature values.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -130,7 +130,7 @@ def run_summary(
         If ``True``, overwrite any existing output under ``output_dir``.
         Defaults to ``False``.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -65,7 +65,7 @@ def run_experiment(
         If ``True``, overwrite any existing output under ``output_dir``.
         Defaults to ``False``.
     logger : Optional[logging.Logger]
-        A logging object. If ``None`` is passed, get logger from ``__name__``.
+        A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
     wandb_run : Optional[Run]
         A wandb run object that will be used to log artifacts and tables.

--- a/rsmtool/rsmxval.py
+++ b/rsmtool/rsmxval.py
@@ -94,7 +94,7 @@ def run_cross_validation(
         rsmtool for each fold. This option should only be used when
         running the unit tests.
         Defaults to ``False``.
-    wandb_run : Run
+    wandb_run : wandb.wandb_run.Run
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
         wandb is enabled in the configuration. Defaults to ``None``.


### PR DESCRIPTION
### Changes

- Minor typos in docstrings.
- Add `sphinx-autodoc-typehints` dependency.
- Improve sphinx auto documentation.
- Add type hints to `container.py`
- Add type hints to `analyzer.py`
- Add type hints to `comparer.py`.
- Add type hints to `configuration_parser.py`

### To review

- Please check that I have not left any parameters/arguments/return values without type hints. 
- Here's the [RTD build for this branch](https://rsmtool.readthedocs.io/en/326-type-hints-2). Check the "API Documentation" section (only for the files affected by this MR and the previous one) to confirm that all types are linked to relevant pages from external documentations (e.g., Python, Numpy, SKLL). There's no W&B yet since it doesn't seem to work. I have a ticket open with them.
- Check for typos and/or weird issues in docstrings. 

