### PR TITLE
Add Type Hints (Part 4)

### DIFF
--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -1718,7 +1718,7 @@ class Analyzer:
             parameters (keys):  {"subgroups", "second_human_score_column",
             "use_scaled_predictions"}.
 
-        wandb_run : wandb.wandb_run.Run
+        wandb_run : Optional[wandb.wandb_run.Run]
             The wandb run object if wandb is enabled, ``None`` otherwise.
             If enabled, all the output data frames will be logged to this run
             as tables.

--- a/rsmtool/analyzer.py
+++ b/rsmtool/analyzer.py
@@ -51,11 +51,10 @@ class Analyzer:
 
         Parameters
         ----------
-        data_container : rsmtool.container.DataContainer
+        data_container : DataContainer
             A DataContainer object
         dataframe_names : List[str]
-            The names of the DataFrames expected in the
-            DataContainer object.
+            The names of the DataFrames expected in the DataContainer object.
 
         Raises
         ------

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -584,7 +584,7 @@ class Reporter:
 
     def create_report(
         self, config: Configuration, csvdir: str, figdir: str, context: str = "rsmtool"
-    ):
+    ) -> None:
         """
         Generate HTML report for an rsmtool/rsmeval experiment.
 
@@ -636,9 +636,14 @@ class Reporter:
             trim_tolerance,
         ) = config.get_trim_min_max_tolerance()
 
-        if used_trim_min and used_trim_max and trim_tolerance:
-            min_score = used_trim_min - trim_tolerance
-            max_score = used_trim_max + trim_tolerance
+        # at this point, all the trim parameters should be available
+        # but let's make sure for mypy
+        assert (
+            used_trim_min is not None and used_trim_max is not None and trim_tolerance is not None
+        )
+
+        min_score = used_trim_min - trim_tolerance
+        max_score = used_trim_max + trim_tolerance
 
         environ_config = {
             "EXPERIMENT_ID": config["experiment_id"],

--- a/rsmtool/rsmeval.py
+++ b/rsmtool/rsmeval.py
@@ -64,10 +64,11 @@ def run_evaluation(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
-        wandb is enabled in the configuration. Defaults to ``None``.
+        wandb is enabled in the configuration.
+        Defaults to ``None``.
 
     Raises
     ------

--- a/rsmtool/rsmexplain.py
+++ b/rsmtool/rsmexplain.py
@@ -175,7 +175,7 @@ def generate_explanation(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
         wandb is enabled in the configuration.
@@ -462,7 +462,7 @@ def generate_report(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
         wandb is enabled in the configuration. Defaults to ``None``.

--- a/rsmtool/rsmpredict.py
+++ b/rsmtool/rsmpredict.py
@@ -344,10 +344,11 @@ def compute_and_save_predictions(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
-        wandb is enabled in the configuration. Defaults to ``None``.
+        wandb is enabled in the configuration.
+        Defaults to ``None``.
 
     Raises
     ------

--- a/rsmtool/rsmsummarize.py
+++ b/rsmtool/rsmsummarize.py
@@ -132,10 +132,11 @@ def run_summary(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
-        wandb is enabled in the configuration. Defaults to ``None``.
+        wandb is enabled in the configuration.
+        Defaults to ``None``.
 
     Raises
     ------

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -69,10 +69,11 @@ def run_experiment(
     logger : Optional[logging.Logger]
         A Logger object. If ``None`` is passed, get logger from ``__name__``.
         Defaults to ``None``.
-    wandb_run : Optional[Run]
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
-        wandb is enabled in the configuration. Defaults to ``None``.
+        wandb is enabled in the configuration.
+        Defaults to ``None``.
 
     Raises
     ------

--- a/rsmtool/rsmtool.py
+++ b/rsmtool/rsmtool.py
@@ -229,6 +229,7 @@ def run_experiment(
 
     # Identify the features used by the model
     selected_features = modeler.get_feature_names()
+    assert selected_features is not None
 
     # Add selected features to processed configuration
     processed_config["selected_features"] = selected_features

--- a/rsmtool/rsmxval.py
+++ b/rsmtool/rsmxval.py
@@ -94,10 +94,11 @@ def run_cross_validation(
         rsmtool for each fold. This option should only be used when
         running the unit tests.
         Defaults to ``False``.
-    wandb_run : wandb.wandb_run.Run
+    wandb_run : Optional[wandb.wandb_run.Run]
         A wandb run object that will be used to log artifacts and tables.
         If ``None`` is passed, a new wandb run will be initialized if
-        wandb is enabled in the configuration. Defaults to ``None``.
+        wandb is enabled in the configuration.
+        Defaults to ``None``.
 
     Raises
     ------

--- a/rsmtool/test_utils.py
+++ b/rsmtool/test_utils.py
@@ -93,6 +93,7 @@ def check_run_experiment(
         Configuration object or dictionary to use as an input, if any.
         If ``None``, the function will construct a path to the config file
         using ``"source"`` and ``"experiment_id"``.
+        Defults to ``None``.
     suppress_warnings_for : List[Type]
         Types for which warnings should be suppressed when running the experiments.
         Defaults to ``[]``.
@@ -542,6 +543,7 @@ def check_run_cross_validation(
         Configuration object or dictionary to use as an input, if any.
         If ``None``, the function will construct a path to the config file
         using ``"source"`` and ``"experiment_id"``.
+        Defaults to ``None``.
     suppress_warnings_for : List[Type]
         Types for which warnings should be suppressed when running the
         experiments.

--- a/rsmtool/transformer.py
+++ b/rsmtool/transformer.py
@@ -9,19 +9,31 @@ Class for transforming features.
 """
 
 import logging
+from typing import Callable, Dict, Optional
 
 import numpy as np
+import pandas as pd
 from scipy.stats.stats import pearsonr
 
 
 class FeatureTransformer:
     """Encapsulate feature transformation methods."""
 
-    def __init__(self, logger=None):
-        """Initialize the FeatureTransformer object."""
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        """
+        Initialize the FeatureTransformer object.
+
+        Parameters
+        ----------
+        logger : Optional[logging.Logger]
+            Logger object to use in the transformer. If not provided,
+            a logger will be created with the name of this class.
+        """
         self.logger = logger if logger else logging.getLogger(__name__)
 
-    def apply_sqrt_transform(self, name, values, raise_error=True):
+    def apply_sqrt_transform(
+        self, name: str, values: np.ndarray, raise_error: bool = True
+    ) -> np.ndarray:
         """
         Apply the "sqrt" transform to ``values``.
 
@@ -29,16 +41,16 @@ class FeatureTransformer:
         ----------
         name : str
             Name of the feature to transform.
-        values : np.array
+        values : numpy.ndarray
             Numpy array containing the feature values.
-        raise_error : bool, optional
+        raise_error : bool
             If ``True``, raises an error if the transform is applied to
             a feature that has negative values.
             Defaults to ``True``.
 
         Returns
         -------
-        new_data : np.array
+        new_data : numpy.ndarray
             Numpy array containing the transformed feature values.
 
         Raises
@@ -65,7 +77,9 @@ class FeatureTransformer:
             new_data = np.sqrt(values)
         return new_data
 
-    def apply_log_transform(self, name, values, raise_error=True):
+    def apply_log_transform(
+        self, name: str, values: np.ndarray, raise_error: bool = True
+    ) -> np.ndarray:
         """
         Apply the "log" transform to ``values``.
 
@@ -73,18 +87,17 @@ class FeatureTransformer:
         ----------
         name : str
             Name of the feature to transform.
-        values : np.array
+        values : numpy.ndarray
             Numpy array containing the feature values.
-        raise_error : bool, optional
+        raise_error : bool
             If ``True``, raises an error if the transform is applied to
             a feature that has zero or negative values.
             Defaults to ``True``.
 
         Returns
         -------
-        new_data : numpy array
-            Numpy array containing the transformed feature
-            values.
+        new_data : numpy.ndarray
+            Numpy array containing the transformed feature values.
 
         Raises
         ------
@@ -123,7 +136,9 @@ class FeatureTransformer:
         new_data = np.log(values)
         return new_data
 
-    def apply_inverse_transform(self, name, values, raise_error=True, sd_multiplier=4):
+    def apply_inverse_transform(
+        self, name: str, values: np.ndarray, raise_error: bool = True, sd_multiplier: int = 4
+    ) -> np.ndarray:
         """
         Apply the "inv" (inverse) transform to ``values``.
 
@@ -131,24 +146,22 @@ class FeatureTransformer:
         ----------
         name : str
             Name of the feature to transform.
-        values : np.array
+        values : numpy.ndarray
             Numpy array containing the feature values.
-        raise_error : bool, optional
-            If ``True``, raises an error if the transform is applied to
-            a feature that has zero values or to a feature that has
-           both positive and negative values.
+        raise_error : bool
+            If ``True``, raises an error if the transform is applied to a feature
+            that has zero values or to a feature that has both positive and
+            negative values.
             Defaults to ``True``.
-        sd_multiplier : int, optional
-            Use this std. dev. multiplier to compute the ceiling
-            and floor for outlier removal and check that these
-            are not equal to zero.
+        sd_multiplier : int
+            Use this std. dev. multiplier to compute the ceiling and floor for
+            outlier removal and check that these are not equal to zero.
             Defaults to 4.
 
         Returns
         -------
-        new_data : np.array
-            Numpy array containing the transformed feature
-            values.
+        new_data : numpy.ndarray
+            Numpy array containing the transformed feature values.
 
         Raises
         ------
@@ -202,7 +215,9 @@ class FeatureTransformer:
 
         return new_data
 
-    def apply_add_one_inverse_transform(self, name, values, raise_error=True):
+    def apply_add_one_inverse_transform(
+        self, name: str, values: np.ndarray, raise_error: bool = True
+    ) -> np.ndarray:
         """
         Apply the "addOneInv" (add one and invert) transform to ``values``.
 
@@ -210,16 +225,16 @@ class FeatureTransformer:
         ----------
         name : str
             Name of the feature to transform.
-        values : np.array
+        values : numpy.ndarray
             Numpy array containing the feature values.
-        raise_error : bool, optional
+        raise_error : bool
             If ``True``, raises an error if the transform is applied to
             a feature that has zero or negative values.
             Defaults to ``True``.
 
         Returns
         -------
-        new_data : np.array
+        new_data : numpy.ndarray
             Numpy array containing the transformed feature values.
 
         Raises
@@ -246,7 +261,9 @@ class FeatureTransformer:
         new_data = 1 / (values + 1)
         return new_data
 
-    def apply_add_one_log_transform(self, name, values, raise_error=True):
+    def apply_add_one_log_transform(
+        self, name: str, values: np.ndarray, raise_error: bool = True
+    ) -> np.ndarray:
         """
         Apply the "addOneLn" (add one and log) transform to ``values``.
 
@@ -254,16 +271,16 @@ class FeatureTransformer:
         ----------
         name : str
             Name of the feature to transform.
-        values : np.array
+        values : numpy.ndarray
             Numpy array containing the feature values.
-        raise_error : bool, optional
+        raise_error : bool
             If ``True``, raises an error if the transform is applied to
             a feature that has zero or negative values.
             Defaults to ``True``.
 
         Returns
         -------
-        new_data : np.array
+        new_data : numpy.ndarray
             Numpy array that contains the transformed feature values.
 
         Raises
@@ -290,7 +307,9 @@ class FeatureTransformer:
         new_data = np.log(values + 1)
         return new_data
 
-    def transform_feature(self, values, column_name, transform, raise_error=True):
+    def transform_feature(
+        self, values: np.ndarray, column_name: str, transform: str, raise_error: bool = True
+    ) -> np.ndarray:
         """
         Apply given transform to all values in the given numpy array.
 
@@ -298,21 +317,21 @@ class FeatureTransformer:
 
         Parameters
         ----------
-        values : numpy array
+        values : numpy.ndarray
             Numpy array containing the feature values.
         column_name : str
             Name of the feature to transform.
         transform : str
-            Name of the transform to apply. One of {"inv", "sqrt", "log",
-            "addOneInv", "addOneLn", "raw", "org"}.
-        raise_error : bool, optional
+            Name of the transform to apply. One of {``"inv"``, ``"sqrt"``,
+            ``"log"``, ``"addOneInv"``, ``"addOneLn"``, ``"raw"``, ``"org"``}.
+        raise_error : bool
             If ``True``, raise a ValueError if a transformation leads to
             invalid values or may change the ranking of the responses.
             Defaults to ``True``.
 
         Returns
         -------
-        new_data : np.array
+        new_data : numpy.ndarray
             Numpy array containing the transformed feature values.
 
         Raises
@@ -326,25 +345,27 @@ class FeatureTransformer:
         span both negative and positive values. Some transformations may
         throw errors for negative feature values.
         """
-        transforms = {
+        transforms: Dict[str, Callable] = {
             "inv": self.apply_inverse_transform,
             "sqrt": self.apply_sqrt_transform,
             "log": self.apply_log_transform,
             "addOneInv": self.apply_add_one_inverse_transform,
             "addOneLn": self.apply_add_one_log_transform,
-            "raw": lambda column_name, data, raise_error: data,
-            "org": lambda column_name, data, raise_error: data,
+            "raw": lambda data: data,
+            "org": lambda data: data,
         }
 
         # make sure we have a valid transform function
         if transform is None or transform not in transforms:
-            raise ValueError(f"Unrecognized feature transformation:  {transform}")
+            raise ValueError(f"Unrecognized feature transformation: {transform}")
 
-        transformer = transforms.get(transform)
+        transformer = transforms[transform]
         new_data = transformer(column_name, values, raise_error)
         return new_data
 
-    def find_feature_transform(self, feature_name, feature_value, scores):
+    def find_feature_transform(
+        self, feature_name: str, feature_value: pd.Series, scores: pd.Series
+    ) -> str:
         """
         Identify best transformation for feature given correlation with score.
 
@@ -355,9 +376,9 @@ class FeatureTransformer:
         ----------
         feature_name: str
             Name of feature for which to find the transformation.
-        feature_value: pandas Series
+        feature_value: pandas.Series
             Series containing feature values.
-        scores: pandas Series
+        scores: pandas.Series
             Numeric human scores.
 
         Returns

--- a/rsmtool/transformer.py
+++ b/rsmtool/transformer.py
@@ -360,7 +360,8 @@ class FeatureTransformer:
             raise ValueError(f"Unrecognized feature transformation: {transform}")
 
         transformer = transforms[transform]
-        new_data = transformer(column_name, values, raise_error)
+        args = [column_name, values, raise_error] if transform not in ["raw", "org"] else [values]
+        new_data = transformer(*args)
         return new_data
 
     def find_feature_transform(

--- a/rsmtool/writer.py
+++ b/rsmtool/writer.py
@@ -34,10 +34,12 @@ class DataWriter:
 
         Parameters
         ----------
-        experiment_id : str
-            The experiment name to be used in the output file names
-        context : str
-            The context in which this writer is used. Defaults to ``None``.
+        experiment_id : Optional[str]
+            The experiment name to be used in the output file names.
+            Defaults to ``None``.
+        context : Optional[str]
+            The context in which this writer is used.
+            Defaults to ``None``.
         wandb_run : Optional[wandb.wandb_run.Run]
             The wandb run object if wandb is enabled, None otherwise.
             If enabled, all the output data frames will be logged to
@@ -64,7 +66,7 @@ class DataWriter:
             This includes everything except the extension.
         file_format : str
             The file format (extension) for the file to be written to disk.
-            One of {``"csv"``, ``"xlsx"``, `"tsv"`}.
+            One of {``"csv"``, ``"xlsx"``, ``"tsv"``}.
             Defaults to ``"csv"``.
         index : bool
             Whether to include the index in the output file.

--- a/rsmtool/writer.py
+++ b/rsmtool/writer.py
@@ -10,6 +10,12 @@ Class for writing DataContainer frames to disk.
 
 from os import makedirs
 from os.path import join
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+from wandb.wandb_run import Run
+
+from rsmtool.container import DataContainer
 
 from .utils.wandb import log_dataframe_to_wandb
 
@@ -17,7 +23,12 @@ from .utils.wandb import log_dataframe_to_wandb
 class DataWriter:
     """Class to write out DataContainer objects."""
 
-    def __init__(self, experiment_id=None, context=None, wandb_run=None):
+    def __init__(
+        self,
+        experiment_id: Optional[str] = None,
+        context: Optional[str] = None,
+        wandb_run: Optional[Run] = None,
+    ):
         """
         Initialize the DataWriter object.
 
@@ -27,7 +38,7 @@ class DataWriter:
             The experiment name to be used in the output file names
         context : str
             The context in which this writer is used. Defaults to ``None``.
-        wandb_run : wandb.Run
+        wandb_run : Optional[wandb.wandb_run.Run]
             The wandb run object if wandb is enabled, None otherwise.
             If enabled, all the output data frames will be logged to
             this run as tables.
@@ -38,7 +49,9 @@ class DataWriter:
         self.wandb_run = wandb_run
 
     @staticmethod
-    def write_frame_to_file(df, name_prefix, file_format="csv", index=False, **kwargs):
+    def write_frame_to_file(
+        df: pd.DataFrame, name_prefix: str, file_format: str = "csv", index: bool = False, **kwargs
+    ) -> None:
         """
         Write given data frame to disk with given name and file format.
 
@@ -51,9 +64,9 @@ class DataWriter:
             This includes everything except the extension.
         file_format : str
             The file format (extension) for the file to be written to disk.
-            One of {"csv", "xlsx", "tsv"}.
-            Defaults to "csv".
-        index : bool, optional
+            One of {``"csv"``, ``"xlsx"``, `"tsv"`}.
+            Defaults to ``"csv"``.
+        index : bool
             Whether to include the index in the output file.
             Defaults to ``False``.
 
@@ -91,16 +104,16 @@ class DataWriter:
 
     def write_experiment_output(
         self,
-        csvdir,
-        container_or_dict,
-        dataframe_names=None,
-        new_names_dict=None,
-        include_experiment_id=True,
-        reset_index=False,
-        file_format="csv",
-        index=False,
+        csvdir: str,
+        container_or_dict: Union[DataContainer, Dict[str, pd.DataFrame]],
+        dataframe_names: Optional[List[str]] = None,
+        new_names_dict: Optional[Dict[str, str]] = None,
+        include_experiment_id: bool = True,
+        reset_index: bool = False,
+        file_format: str = "csv",
+        index: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         """
         Write out each of the named frames to disk.
 
@@ -117,30 +130,29 @@ class DataWriter:
         csvdir : str
             Path to the output experiment sub-directory that will
             contain the CSV files corresponding to each of the data frames.
-        container_or_dict : container.DataContainer or dict
+        container_or_dict : Union[container.DataContainer, Dict[str, pd.DataFrame]]
             A DataContainer object or dict, where keys are data frame
-            names and values are ``pd.DataFrame`` objects.
-        dataframe_names : list of str, optional
+            names and values are pandas.DataFrame objects.
+        dataframe_names : Optional[List[str]]
             List of data frame names, one for each of the data frames.
             Defaults to ``None``.
-        new_names_dict : dict, optional
+        new_names_dict : Optional[Dict[str, str]]
             New dictionary with new names for the data frames, if desired.
             Defaults to ``None``.
-        include_experiment_id : str, optional
+        include_experiment_id : bool
             Whether to include the experiment ID in the file name.
             Defaults to ``True``.
-        reset_index : bool, optional
+        reset_index : bool
             Whether to reset the index of each data frame
             before writing to disk.
             Defaults to ``False``.
-        file_format : str, optional
+        file_format : str
             The file format in which to output the data.
-            One of {"csv", "xlsx", "tsv"}.
-            Defaults to "csv".
-        index : bool, optional
+            One of {``"csv"``, ``"xlsx"``, ``"tsv"``}.
+            Defaults to ``"csv"``.
+        index : bool
             Whether to include the index in the output file.
             Defaults to ``False``.
-
 
         Raises
         ------
@@ -152,7 +164,7 @@ class DataWriter:
 
         # If no `dataframe_names` specified, use all names
         if dataframe_names is None:
-            dataframe_names = container_or_dict.keys()
+            dataframe_names = list(container_or_dict.keys())
 
         # Otherwise, check to make sure all specified names
         # are actually in the DataContainer
@@ -196,12 +208,12 @@ class DataWriter:
 
     def write_feature_csv(
         self,
-        featuredir,
-        data_container,
-        selected_features,
-        include_experiment_id=True,
-        file_format="csv",
-    ):
+        featuredir: str,
+        data_container: DataContainer,
+        selected_features: List[str],
+        include_experiment_id: bool = True,
+        file_format: str = "csv",
+    ) -> None:
         """
         Write out the selected features to disk.
 
@@ -210,17 +222,17 @@ class DataWriter:
         featuredir : str
             Path to the experiment output directory where the
             feature JSON file will be saved.
-        data_container : container.DataContainer
+        data_container : DataContainer
             A data container object.
-        selected_features : list of str
+        selected_features : List[str]
             List of features that were selected for model building.
-        include_experiment_id : bool, optional
+        include_experiment_id : bool
             Whether to include the experiment ID in the file name.
             Defaults to ``True``.
-        file_format : str, optional
-            The file format in which to output the data.
-            One of {"csv", "tsv", "xlsx"}.
-            Defaults to "csv".
+        file_format : str
+            The file format in which to output the data. One of {``"csv"``, ``"tsv"``,
+            ``"xlsx"``}.
+            Defaults to ``"csv"``.
         """
         df_feature_specs = data_container["feature_specs"]
 

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -12,7 +12,7 @@ from rsmtool.test_utils import do_run_experiment
 
 
 class TestComparer(unittest.TestCase):
-    """Test class for Comparer tests"""
+    """Test class for Comparer tests."""
 
     def test_make_summary_stat_df(self):
         array = np.random.multivariate_normal([100, 25], [[25, 0.5], [0.5, 1]], 5000)
@@ -197,7 +197,7 @@ class TestComparer(unittest.TestCase):
         experiment_id = "lr_subgroups_with_h2"
         test_dir = dirname(__file__)
         config_file = join(test_dir, "data", "experiments", source, f"{experiment_id}.json")
-        do_run_experiment(source, experiment_id, config_file)
+        do_run_experiment(source, config_file)
         output_dir = join("test_outputs", source, "output")
         figure_dir = join("test_outputs", source, "figure")
 

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -186,7 +186,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_with_repeated_ids"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_lr_eval_all_non_numeric_scores(self):
         # rsmeval experiment with all values for the human
@@ -197,7 +197,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_all_non_numeric_scores"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_lr_eval_same_system_human_score(self):
         # rsmeval experiment with the same value supplied
@@ -207,7 +207,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_same_system_human_score"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_lr_eval_all_non_numeric_machine_scores(self):
         # rsmeval experiment with all the machine scores`
@@ -218,7 +218,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_all_non_numeric_machine_scores"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_eval_lr_with_missing_h2_column(self):
         # rsmeval experiment with `second_human_score_column`
@@ -228,7 +228,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_with_missing_h2_column"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(KeyError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_eval_lr_with_missing_candidate_column(self):
         # rsmeval experiment with `candidate_column`
@@ -238,7 +238,7 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_with_missing_candidate_column"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(KeyError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)
 
     def test_run_experiment_lr_eval_wrong_path(self):
         # basic rsmeval experiment with wrong path to the
@@ -248,4 +248,4 @@ class TestExperimentRsmeval(unittest.TestCase):
         experiment_id = "lr_eval_with_h2"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(FileNotFoundError):
-            do_run_evaluation(source, experiment_id, config_file)
+            do_run_evaluation(source, config_file)

--- a/tests/test_experiment_rsmeval.py
+++ b/tests/test_experiment_rsmeval.py
@@ -26,18 +26,15 @@ class TestExperimentRsmeval(unittest.TestCase):
         {
             "source": "lr-eval-exclude-listwise",
             "experiment_id": "lr_eval_exclude_listwise",
-            "subgroups": ["QUESTION", "L1"],
         },
         {"source": "lr-eval-exclude-flags", "experiment_id": "lr_eval_exclude_flags"},
         {
             "source": "lr-eval-with-missing-scores",
             "experiment_id": "lr_eval_with_missing_scores",
-            "subgroups": ["QUESTION", "L1"],
         },
         {
             "source": "lr-eval-with-missing-data",
             "experiment_id": "lr_eval_with_missing_data",
-            "subgroups": ["QUESTION", "L1"],
         },
         {
             "source": "lr-eval-with-custom-order",
@@ -48,7 +45,6 @@ class TestExperimentRsmeval(unittest.TestCase):
         {
             "source": "lr-eval-with-custom-sections-and-order",
             "experiment_id": "lr_eval_with_custom_sections_and_order",
-            "subgroups": ["QUESTION", "L1"],
         },
         {"source": "lr-eval-tsv-input-files", "experiment_id": "lr_eval_tsv_input_files"},
         {"source": "lr-eval-xlsx-input-files", "experiment_id": "lr_eval_xlsx_input_files"},
@@ -73,7 +69,6 @@ class TestExperimentRsmeval(unittest.TestCase):
         {
             "source": "lr-eval-with-h2",
             "experiment_id": "lr_eval_with_h2",
-            "subgroups": ["QUESTION", "L1"],
             "consistency": "True",
         },
         {
@@ -103,12 +98,10 @@ class TestExperimentRsmeval(unittest.TestCase):
         {
             "source": "lr-eval-with-numeric-threshold",
             "experiment_id": "lr_evaluation_with_numeric_threshold",
-            "subgroups": ["QUESTION", "L1"],
         },
         {
             "source": "lr-eval-system-score-constant",
             "experiment_id": "lr_eval_system_score_constant",
-            "subgroups": ["QUESTION", "L1"],
             "consistency": "True",
             "suppress_warnings_for": [UserWarning],
         },

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -67,7 +67,7 @@ class TestExperimentRsmpredict(unittest.TestCase):
         rsmtool_config_file = join(
             rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json"
         )
-        do_run_experiment(source, experiment_id, rsmtool_config_file)
+        do_run_experiment(source, rsmtool_config_file)
         rsmpredict_config_file = join(
             rsmtool_test_dir, "data", "experiments", source, "rsmpredict.json"
         )

--- a/tests/test_experiment_rsmtool_1.py
+++ b/tests/test_experiment_rsmtool_1.py
@@ -88,7 +88,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         source = "lr-with-notebook-rerun"
         experiment_id = "lr"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
-        do_run_experiment(source, experiment_id, config_file)
+        do_run_experiment(source, config_file)
 
         report_ipynb = join("test_outputs", source, "report", f"{experiment_id}_report.ipynb")
         report_html = join("test_outputs", source, "report", f"{experiment_id}_report.html")
@@ -106,7 +106,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         source = "lr-with-notebook-rerun-fail"
         experiment_id = "lr"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
-        do_run_experiment(source, experiment_id, config_file)
+        do_run_experiment(source, config_file)
 
         report_env = join("test_outputs", source, "report", ".environ.json")
         report_ipynb = join("test_outputs", source, "report", f"{experiment_id}_report.ipynb")
@@ -125,7 +125,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "lr_with_feature_subset_file"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_sc2_as_feature_name(self):
         # rsmtool experiment with sc2 used as a feature name
@@ -137,7 +137,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
             config_file = join(
                 rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json"
             )
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_subgroup_as_feature_name(self):
         # rsmtool experiment with a subgroup name used as feature
@@ -147,7 +147,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "lr_with_subgroup_as_feature_name"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_all_non_numeric_scores(self):
         # rsmtool experiment with all values for `sc1`
@@ -158,7 +158,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "lr_with_all_non_numeric_scores"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_one_fully_non_numeric_feature(self):
         # rsmtool experiment with all values for one of the
@@ -169,7 +169,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "lr_with_one_fully_non_numeric_feature"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_none_flagged(self):
         # rsmtool experiment where all responses have the bad flag
@@ -180,7 +180,7 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "lr_with_none_flagged"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_wrong_model_name(self):
         # rsmtool experiment with incorrect model name
@@ -188,4 +188,4 @@ class TestExperimentRsmtool1(unittest.TestCase):
         experiment_id = "wrong_model_name"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)

--- a/tests/test_experiment_rsmtool_2.py
+++ b/tests/test_experiment_rsmtool_2.py
@@ -71,7 +71,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_length_and_feature"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_h2_column_and_feature(self):
         # rsmtool experiment that has second rater column but
@@ -80,7 +80,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_h2_and_feature"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_same_h1_and_h2(self):
         # rsmtool experiment that has label column
@@ -90,7 +90,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_same_h1_and_h2"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_repeated_ids(self):
         # rsmtool experiment with non-unique ids
@@ -98,7 +98,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_repeated_ids"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_sc1_as_feature_name(self):
         # rsmtool experiment with sc1 used as the name of a feature
@@ -106,7 +106,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_sc1_as_feature_name"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_length_as_feature_name(self):
         # rsmtool experiment with 'length' used as feature name
@@ -115,7 +115,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_length_as_feature_name"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_truncations_no_features_field(self):
         # rsmtool experiment with truncations, but no feature field
@@ -123,7 +123,7 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_truncations_no_features_field"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_with_truncations_no_features_columns(self):
         # rsmtool experiment with truncations, but no min/max columns in feature file
@@ -131,4 +131,4 @@ class TestExperimentRsmtool2(unittest.TestCase):
         experiment_id = "lr_with_truncations_no_features_columns"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)

--- a/tests/test_experiment_rsmtool_3.py
+++ b/tests/test_experiment_rsmtool_3.py
@@ -219,7 +219,7 @@ class TestExperimentRsmtool3(unittest.TestCase):
         experiment_id = "lr_with_duplicate_feature_names"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_feature_json(self):
         # basic experiment with a LinearRegression model but using
@@ -231,9 +231,7 @@ class TestExperimentRsmtool3(unittest.TestCase):
 
         # run this experiment but suppress the expected deprecation warnings
         with self.assertRaises(ValueError):
-            do_run_experiment(
-                source, experiment_id, config_file, suppress_warnings_for=[DeprecationWarning]
-            )
+            do_run_experiment(source, config_file, suppress_warnings_for=[DeprecationWarning])
 
     def test_run_experiment_wrong_train_file_path(self):
         # basic experiment with the path in train_file field pointing to
@@ -242,7 +240,7 @@ class TestExperimentRsmtool3(unittest.TestCase):
         experiment_id = "lr"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_wrong_feature_file_path(self):
         # basic experiment with the path in features field pointing to
@@ -251,7 +249,7 @@ class TestExperimentRsmtool3(unittest.TestCase):
         experiment_id = "lr"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_lr_length_column_and_feature_list(self):
         # experiment with feature as list instead of file name
@@ -261,4 +259,4 @@ class TestExperimentRsmtool3(unittest.TestCase):
         experiment_id = "lr_with_length_and_feature"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)

--- a/tests/test_experiment_rsmtool_4.py
+++ b/tests/test_experiment_rsmtool_4.py
@@ -119,7 +119,7 @@ class TestExperimentRsmtool4(unittest.TestCase):
         experiment_id = "empWtDropNeg"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_requested_feature_zero_sd(self):
         # rsmtool experiment when a requested feature has zero sd
@@ -127,14 +127,14 @@ class TestExperimentRsmtool4(unittest.TestCase):
         experiment_id = "lr_with_requested_feature_with_zero_sd"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         with self.assertRaises(ValueError):
-            do_run_experiment(source, experiment_id, config_file)
+            do_run_experiment(source, config_file)
 
     def test_run_experiment_with_warnings(self):
         source = "lr-with-warnings"
         experiment_id = "lr_with_warnings"
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
 
-        do_run_experiment(source, experiment_id, config_file)
+        do_run_experiment(source, config_file)
 
         html_file = join("test_outputs", source, "report", experiment_id + "_report.html")
         report_warnings = collect_warning_messages_from_report(html_file)
@@ -172,7 +172,7 @@ class TestExperimentRsmtool4(unittest.TestCase):
         config_file = join(rsmtool_test_dir, "data", "experiments", source, f"{experiment_id}.json")
         mock_wandb_run = Mock()
         mock_wandb_init.return_value = mock_wandb_run
-        do_run_experiment(source, experiment_id, config_file)
+        do_run_experiment(source, config_file)
         mock_wandb_init.assert_called_with(project="wandb_project", entity="wandb_entity")
         mock_wandb_run.log_artifact.assert_called_once()
         mock_plot_conf_mat.assert_called()


### PR DESCRIPTION
### Changes

- Add type hints to `reporter.py`
- Fix some typos in docstrings
- Add type hints to `test_utils.py`
- Add type hints to `transformer.py`
- Add type hints to `writer.py`.
- Fix incorrect number of transformer arguments.
- Remove unneeded argument from `rsmeval` tests.

### How to review
- Please check that I have not left any parameters/arguments/return values without type hints.
- Here's the [RTD build for this branch](https://rsmtool.readthedocs.io/en/326-type-hints-4). Check the "API Documentation" section (for the files affected by this MR) to confirm that all types are linked to relevant pages from external documentations (e.g., Python, Numpy, SKLL, stats models etc.) and there are no typos etc. 
- Check for typos and/or weird issues in docstrings.