### PR TITLE
Fix pandas-related warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy<2
 openpyxl
 pandas
 pre-commit
+pyarrow
 seaborn
 shap
 skll==4.0.1

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -10,6 +10,7 @@ Classes for preprocessing input data in various contexts.
 
 import logging
 import re
+import warnings
 from sys import version_info
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -2339,7 +2340,14 @@ class FeaturePreprocessor:
                 "can be run. "
             )
 
-        with np.errstate(divide="ignore"):
+        # concatenate the excluded data frames but ignore the
+        # FutureWarning about the behavior of Dataframe concatenation
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The behavior of Dataframe concatenation",
+                category=FutureWarning,
+            )
             df_excluded = pd.concat([df_excluded, newdf_excluded], sort=True)
 
         # if requested, exclude the candidates with less than X responses
@@ -2360,8 +2368,17 @@ class FeaturePreprocessor:
             # redefine df_filtered_pred
             df_filtered_pred = df_filtered_candidates.copy()
 
-            # update df_excluded
-            df_excluded = pd.concat([df_excluded, df_excluded_candidates], sort=True)
+            # update df_excluded but ignore the FutureWarning about the
+            # behavior of Dataframe concatenation
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="The behavior of Dataframe concatenation",
+                    category=FutureWarning,
+                )
+                df_excluded = pd.concat([df_excluded, df_excluded_candidates], sort=True)
+
+            # make sure that `spkitemid` is the first column
             df_excluded = df_excluded[
                 ["spkitemid"] + [column for column in df_excluded if column != "spkitemid"]
             ]
@@ -2960,7 +2977,15 @@ class FeaturePreprocessor:
             )
             del df_filtered
             df_filtered = newdf
-            with np.errstate(divide="ignore"):
+
+            # concatenate the excluded data frames but ignore the
+            # FutureWarning about the behavior of Dataframe concatenation
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="The behavior of Dataframe concatenation",
+                    category=FutureWarning,
+                )
                 df_excluded = pd.concat([df_excluded, newdf_excluded], sort=True)
 
         # make sure that the remaining data frame is not empty

--- a/tests/test_experiment_rsmpredict.py
+++ b/tests/test_experiment_rsmpredict.py
@@ -38,10 +38,10 @@ class TestExperimentRsmpredict(unittest.TestCase):
     @params(
         {"source": "lr-predict"},
         {"source": "lr-predict-with-score"},
-        {"source": "lr-predict-missing-values", "excluded": "True"},
+        {"source": "lr-predict-missing-values", "excluded": True},
         {"source": "lr-predict-with-subgroups"},
         {"source": "lr-predict-with-candidate"},
-        {"source": "lr-predict-illegal-transformations", "excluded": "True"},
+        {"source": "lr-predict-illegal-transformations", "excluded": True},
         {"source": "lr-predict-tsv-input-files"},
         {"source": "lr-predict-xlsx-input-files"},
         {"source": "lr-predict-jsonlines-input-files"},


### PR DESCRIPTION
- Add `pyarrow` dependency.
- Ignore Dataframe concatenation warnings.
- Fix typos in argument types in test calls.

Closes #680. 