### PR TITLE
648/add excluded features

### DIFF
--- a/rsmtool/notebooks/data_description.ipynb
+++ b/rsmtool/notebooks/data_description.ipynb
@@ -15,10 +15,7 @@
    "source": [
     "# print the excluded features in the report if exists.\n",
     "if excluded_features:\n",
-    "    if len(excluded_features) == 1:\n",
-    "        display(Markdown(f\"The following feature was excluded because its standard devision in the training set is equal to 0: **{excluded_features[0]}**.\"))\n",
-    "    else:\n",
-    "        display(Markdown(f\"The following features were excluded because their standard devision in the training set is equal to 0: **{\", \".join(excluded_features)}**.\"))"
+    "    display(Markdown(f\"The following feature(s) were excluded because their standard devision in the training set is equal to 0: **{\", \".join(excluded_features)}**.\"))"
    ]
   },
   {

--- a/rsmtool/notebooks/data_description.ipynb
+++ b/rsmtool/notebooks/data_description.ipynb
@@ -13,6 +13,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# print the excluded features in the report if exists.\n",
+    "if excluded_features:\n",
+    "    if len(excluded_features) == 1:\n",
+    "        display(Markdown(f\"The following feature was excluded because its standard devision in the training set is equal to 0: **{excluded_features[0]}**.\"))\n",
+    "    else:\n",
+    "        display(Markdown(f\"The following features were excluded because their standard devision in the training set is equal to 0: **{\", \".join(excluded_features)}**.\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "try:\n",
     "    num_excluded_train = len(df_train_responses_with_excluded_flags)\n",
     "except NameError:\n",

--- a/rsmtool/notebooks/data_description.ipynb
+++ b/rsmtool/notebooks/data_description.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# print the excluded features in the report if exists.\n",
     "if excluded_features:\n",
-    "    display(Markdown(f\"The following feature(s) were excluded because their standard devision in the training set is equal to 0: **{\", \".join(excluded_features)}**.\"))"
+    "    display(Markdown(f\"The following feature(s) were excluded because their standard devision in the training set is equal to 0: **{', '.join(excluded_features)}**.\"))"
    ]
   },
   {

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -234,11 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(Markdown('''This report presents the analysis for **{}**: {}'''.format(experiment_id, description)))\n",
-    "# print the excluded features in the report if exists.\n",
-    "if excluded_features:\n",
-    "    for feature in excluded_features:\n",
-    "        display(Markdown(f\"Feature **{feature}** was excluded from the model because its standard deviation in the training set is equal to 0.\"))"
+    "display(Markdown('''This report presents the analysis for **{}**: {}'''.format(experiment_id, description)))"
    ]
   },
   {

--- a/rsmtool/notebooks/header.ipynb
+++ b/rsmtool/notebooks/header.ipynb
@@ -185,6 +185,7 @@
     "use_thumbnails = environ_config.get('USE_THUMBNAILS')\n",
     "predict_expected_scores = environ_config.get('PREDICT_EXPECTED_SCORES')\n",
     "rater_error_variance = environ_config.get(\"RATER_ERROR_VARIANCE\")\n",
+    "excluded_features = environ_config.get(\"EXCLUDED_ZERO_FEATURE\")\n",
     "\n",
     "# groups for analysis by prompt or subgroup.\n",
     "groups_desc = environ_config.get('GROUPS_FOR_DESCRIPTIVES') \n",
@@ -233,7 +234,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Markdown('''This report presents the analysis for **{}**: {}'''.format(experiment_id, description))"
+    "display(Markdown('''This report presents the analysis for **{}**: {}'''.format(experiment_id, description)))\n",
+    "# print the excluded features in the report if exists.\n",
+    "if excluded_features:\n",
+    "    for feature in excluded_features:\n",
+    "        display(Markdown(f\"Feature **{feature}** was excluded from the model because its standard deviation in the training set is equal to 0.\"))"
    ]
   },
   {

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -363,6 +363,7 @@ class FeaturePreprocessor:
     def __init__(self, logger: Optional[logging.Logger] = None):
         """Initialize the FeaturePreprocessor object."""
         self.logger = logger if logger else logging.getLogger(__name__)
+        self.excluded_features = []
 
     def check_model_name(self, model_name: str) -> str:
         """
@@ -830,6 +831,7 @@ class FeaturePreprocessor:
                     f"training set is equal to 0."
                 )
                 drop_column = True
+                self.excluded_features.append(column)
 
         # if `drop_column` is true, then we need to drop the column
         if drop_column:
@@ -2061,6 +2063,9 @@ class FeaturePreprocessor:
 
         for key, value in internal_options_dict.items():
             new_config_obj[key] = value
+        
+        # include the excluded features in the configuration
+        new_config_obj["excluded_features"] = self.excluded_features
 
         new_container_datasets = [
             DatasetDict({"name": "train_features", "frame": df_train_features}),

--- a/rsmtool/preprocessor.py
+++ b/rsmtool/preprocessor.py
@@ -1522,17 +1522,19 @@ class FeaturePreprocessor:
             # and also replace any non-numeric feature values in already
             # excluded data with NaNs for consistency
             for feat in feature_names:
-                df_excluded[feat] = pd.to_numeric(df_excluded[feat], errors="coerce").astype(float)
-                newdf, newdf_excluded = self.filter_on_column(
-                    df_filtered,
-                    feat,
-                    exclude_zeros=False,
-                    exclude_zero_sd=exclude_zero_sd,
-                )
-                del df_filtered
-                df_filtered = newdf
-                with np.errstate(divide="ignore"):
-                    df_excluded = pd.concat([df_excluded, newdf_excluded], sort=True)
+                # check if `df_filtered` contains data again after filtering out from previous iteration.
+                if len(df_filtered) != 0:
+                    df_excluded[feat] = pd.to_numeric(df_excluded[feat], errors="coerce").astype(float)
+                    newdf, newdf_excluded = self.filter_on_column(
+                        df_filtered,
+                        feat,
+                        exclude_zeros=False,
+                        exclude_zero_sd=exclude_zero_sd,
+                    )
+                    del df_filtered
+                    df_filtered = newdf
+                    with np.errstate(divide="ignore"):
+                        df_excluded = pd.concat([df_excluded, newdf_excluded], sort=True)
 
             # make sure that the remaining data frame is not empty
             if len(df_filtered) == 0:

--- a/rsmtool/reporter.py
+++ b/rsmtool/reporter.py
@@ -680,6 +680,7 @@ class Reporter:
             "JAVASCRIPT_PATH": javascript_path,
             "OUTPUT_DIR": csvdir,
             "FIGURE_DIR": figdir,
+            "EXCLUDED_ZERO_FEATURE": config.get("excluded_features", None)
         }
 
         # get the report directory which is at the same level


### PR DESCRIPTION
closes #648 

The PR resolves two issues:
- Add a condition to check if `df_filtered` is empty after filtering out from previous iteration.
- Include the zero SD features message in the report. 


How to test:
1. Check to this branch. 
2. cd to the `examples/rsmtool`. Add/modify a/more new columns with all values as string to the `train.csv`. 
3. Run rsmtool command. 
4. Check the message on the command, ensure only the new added/modified columns are printed. 
5. Revert the changes in the `train.csv`
6. Add a/more new columns with all values being 1. 
7. Run rsmtool commmand. 
8. Check the final report to ensure that the zero excluded feature messages are added in the top of the report. 